### PR TITLE
add benchmark framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 Cargo.lock
 .idea
 .DS_Store
+
+*.bz2
+*.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,10 @@ kafka = "0.8"
 # websocket
 tungstenite="0.16.0"
 url = "2.1.0"
+
+criterion = {version="0.3", features=["html_reports"]}
+
+[[bench]]
+name = "bench_main"
+harness = false
+

--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ information to save at each elem, that consuming more memory.
 
 [mrt-record-doc]: https://docs.rs/bgp-models/0.3.4/bgp_models/mrt/struct.MrtRecord.html
 
-
 ## Contribution
 
 Issues and pull requests are welcome!

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,20 @@
+# Benchmarking
+
+We implement benchmark here with comparisons against some popular alternative parsers.
+
+## Setting Up
+
+Run `bash download.sh` to download test data files to `/tmp` directory.
+
+## Run benchmarks
+
+Run `cargo bench` anywhere in the project will run all benchmarks.
+
+## Implemented Benchmarks
+
+- [X] BGPKIT Parser
+- [X] [bgpdump](https://github.com/RIPE-NCC/bgpdump)
+- [ ] [libparsebgp](https://github.com/CAIDA/libparsebgp)
+- [ ] [bgpscanner](https://gitlab.com/Isolario/bgpscanner)
+- [ ] [micro bgp suite](https://git.doublefourteen.io/bgp/ubgpsuite)
+- [ ] [mrt-parser](https://github.com/sdstrowes/mrt-parser)

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_main;
+
+mod benchmarks;
+
+criterion_main! {
+    benchmarks::bgpdump::bgpdump,
+    benchmarks::bgpkit_parser::bgpkit_parser,
+}

--- a/benches/benchmarks/bgpdump.rs
+++ b/benches/benchmarks/bgpdump.rs
@@ -1,0 +1,21 @@
+use std::process::{Command, Stdio};
+use criterion::{Criterion,criterion_group};
+
+fn parse_with_bgpdump(path: &str) {
+    let _output = Command::new("/opt/homebrew/bin/bgpdump").arg("-M").arg(path)
+        .stdout(Stdio::null())
+        .output();
+}
+
+fn bgpdump_benches(c: &mut Criterion) {
+
+    let mut group = c.benchmark_group("parsing update file");
+    group.sample_size(10);
+
+    group.bench_function("parse rib bgpdump", |b| b.iter(|| parse_with_bgpdump("rib-example.bz2")));
+    group.bench_function("parse update bgpdump", |b| b.iter(|| parse_with_bgpdump("update-example.gz")));
+
+    group.finish();
+}
+
+criterion_group!(bgpdump, bgpdump_benches);

--- a/benches/benchmarks/bgpkit_parser.rs
+++ b/benches/benchmarks/bgpkit_parser.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, Criterion};
+use bgpkit_parser::BgpkitParser;
+
+fn parse_update(path: &str, print: bool) {
+    let parser = BgpkitParser::new(path).unwrap();
+    for elem in parser {
+        if print {
+            let _elem_str = elem.to_string();
+        }
+    }
+}
+
+fn bgpkit_parser_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parsing update file");
+    group.sample_size(10);
+
+    group.bench_function("parse rib no-print", |b| b.iter(|| parse_update("/tmp/rib-example.bz2", false)));
+    group.bench_function("parse rib with-print", |b| b.iter(|| parse_update("/tmp/rib-example.bz2", true)));
+
+    group.bench_function("parse update no-print", |b| b.iter(|| parse_update("/tmp/update-example.gz", false)));
+    group.bench_function("parse update with-print", |b| b.iter(|| parse_update("/tmp/update-example.gz", true)));
+
+    group.finish();
+}
+
+criterion_group!(bgpkit_parser, bgpkit_parser_benches);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,0 +1,2 @@
+pub mod bgpdump;
+pub mod bgpkit_parser;

--- a/benches/download.sh
+++ b/benches/download.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+RIB_LOCAL=/tmp/rib-example.bz2
+RIB_REMOTE=https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/rib-example.bz2
+
+UPD_LOCAL=/tmp/update-example.gz
+UPD_REMOTE=https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example.gz
+
+if test -f "$RIB_LOCAL"; then
+    echo "rib file already exist: $RIB_LOCAL"
+  else
+    curl --silent $RIB_REMOTE -o $RIB_LOCAL
+    echo "rib file downloaded to: $RIB_LOCAL"
+fi
+
+if test -f "$UPD_LOCAL"; then
+    echo "rib file already exist: $UPD_LOCAL"
+  else
+    curl --silent $UPD_REMOTE -o $UPD_LOCAL
+    echo "rib file downloaded to: $UPD_LOCAL"
+fi


### PR DESCRIPTION
This PR adds the basic benchmark framework for measuring performance of BGPKIT parser and other alternative solutions.

This PR paves the way for resolving #12 and added one alternative solution benchmark for `bgpdump`.