### PR TITLE
use `BgpElem` from bgp_models crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ipnetwork = "0.18"
 enum-primitive-derive = "0.1"
 num-traits = "0.1"
 chrono = "0.4"
-bgp-models = "0.3.4"
+bgp-models = "0.4.0"
 
 # logging
 log="0.4"
@@ -33,6 +33,8 @@ reqwest = { version = "0.11", features = ["json", "blocking", "stream"]}
 # ris-live parsing
 serde={version="1.0.130", features=["derive"]}
 serde_json = "1.0.69"
+
+openssl = { version = "0.10", features = ["vendored"] }
 
 # bmp/openbmp parsing
 hex="0.4.3"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,7 +14,8 @@ pub(crate) use bgp::attributes::AttributeParser;
 pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message, parse_mrt_record, };
 
 pub use crate::error::ParserError;
-pub use mrt::mrt_elem::{BgpElem, Elementor, ElemType};
+pub use mrt::mrt_elem::Elementor;
+pub use bgp_models::prelude::{BgpElem, ElemType};
 use crate::io::get_reader;
 
 pub struct BgpkitParser {


### PR DESCRIPTION
It simplifies our code, and allowing reuse of the `BgpElem` structs from other crates.