### PR TITLE
update io to stream processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgpkit-parser"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"
@@ -28,6 +28,7 @@ itertools = "0.10.1"
 bzip2="0.4.3"
 flate2="1.0.22"
 reqwest = { version = "0.11", features = ["json", "blocking", "stream"]}
+isahc = "1.6.0"
 
 
 # ris-live parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ itertools = "0.10.1"
 
 bzip2="0.4.3"
 flate2="1.0.22"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream"]}
 isahc = "1.6.0"
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::io::ErrorKind;
 pub enum ParserError {
     IoError(io::Error, Option<Vec<u8>>),
     EofError(io::Error, Option<Vec<u8>>),
-    RemoteIoError(reqwest::Error),
+    RemoteIoError(String),
     EofExpected,
     ParseError(String),
     UnknownAttr(String),
@@ -35,9 +35,15 @@ impl fmt::Display for ParserError {
     }
 }
 
-impl convert::From<reqwest::Error> for ParserError {
-    fn from(error: reqwest::Error) -> Self {
-        ParserError::RemoteIoError(error)
+impl convert::From<isahc::Error> for ParserError {
+    fn from(error: isahc::Error) -> Self {
+        ParserError::RemoteIoError(error.to_string())
+    }
+}
+
+impl convert::From<isahc::http::Error> for ParserError {
+    fn from(error: isahc::http::Error) -> Self {
+        ParserError::RemoteIoError(error.to_string())
     }
 }
 


### PR DESCRIPTION
instead of loading entire file into memory, it now processes
bytes as they come in from a stream, either locally or remotely.

for handling remote stream processing without using async
runtime, we decided to use isahc library instead of reqwest.
currently, by default no connection timeout is set. we may need to
revise that in the future versions if issues arrive.