### PR TITLE
support display extended and large communities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgpkit-parser"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"
@@ -23,7 +23,7 @@ ipnetwork = "0.18"
 enum-primitive-derive = "0.1"
 num-traits = "0.1"
 chrono = "0.4"
-bgp-models = "0.5"
+bgp-models = "0.6.0-rc.1"
 
 # logging
 log="0.4"

--- a/examples/extended_communities.rs
+++ b/examples/extended_communities.rs
@@ -1,0 +1,29 @@
+use bgp_models::prelude::MetaCommunity;
+use bgpkit_parser::BgpkitParser;
+
+/// This example shows how to printout BGP messages with extended or large communities;
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    log::info!("downloading updates file");
+
+    // create a parser that takes the buffered reader
+    let parser = BgpkitParser::new("http://archive.routeviews.org/bgpdata/2021.10/UPDATES/updates.20211001.0000.bz2").unwrap();
+
+    log::info!("parsing updates file");
+    // iterating through the parser. the iterator returns `BgpElem` one at a time.
+    for elem in parser {
+        if let Some(cs) = &elem.communities {
+            for c in cs {
+                match c {
+                    MetaCommunity::Community(_) => {}
+                    MetaCommunity::ExtendedCommunity(_) |
+                    MetaCommunity::LargeCommunity(_) => {
+                        log::info!("{}", &elem);
+                    }
+                }
+            }
+        }
+    }
+    log::info!("done");
+}

--- a/src/parser/rislive/mod.rs
+++ b/src/parser/rislive/mod.rs
@@ -46,6 +46,7 @@ use crate::BgpElem;
 use std::net::IpAddr;
 use bgp_models::bgp::community::Community;
 use bgp_models::bgp::attributes::Origin::{EGP, IGP, INCOMPLETE};
+use bgp_models::bgp::MetaCommunity;
 use bgp_models::network::NetworkPrefix;
 use ipnetwork::IpNetwork;
 use crate::parser::ElemType;
@@ -108,9 +109,10 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
                     let communities = match community {
                         None => {None}
                         Some(cs) => {
-                            let mut comms: Vec<Community> = vec![];
+                            let mut comms: Vec<MetaCommunity> = vec![];
                             for c in cs {
-                                comms.push(Community::Custom(c.0,c.1));
+                                comms.push(
+                                    MetaCommunity::Community(Community::Custom(c.0,c.1)));
                             }
                             Some(comms)
                         }


### PR DESCRIPTION
This PR adds support for outputting extended and large communities, and uses updated `bgp-models` crate to support serialization of the entire `MrtRecord`s.