### PR TITLE
update parsing of collector and peer bgp id to ipv4addr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ipnetwork = "0.18"
 enum-primitive-derive = "0.1"
 num-traits = "0.1"
 chrono = "0.4"
-bgp-models = "0.6.0-rc.1"
+bgp-models = "0.6.0-rc.3"
 
 # logging
 log="0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgpkit-parser"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"

--- a/examples/peer_index_table.rs
+++ b/examples/peer_index_table.rs
@@ -1,4 +1,3 @@
-use bgp_models::mrt::MrtRecord;
 use serde_json::{json, to_string_pretty};
 
 /// This example reads from TableDumpV2-formatted RIB dump from RIPE RIS and print out the JSON-formatted

--- a/src/parser/mrt/messages/table_dump_v2_message.rs
+++ b/src/parser/mrt/messages/table_dump_v2_message.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use crate::error::ParserError;
 use std::io::{Read, Take};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use bgp_models::mrt::tabledump::{Peer, PeerIndexTable, RibAfiEntries, RibEntry, TableDumpV2Message, TableDumpV2Type};
 use bgp_models::network::*;
 use num_traits::FromPrimitive;
@@ -37,7 +37,7 @@ pub fn parse_table_dump_v2_message<T: Read>(
 ///
 /// https://tools.ietf.org/html/rfc6396#section-4.3
 pub fn parse_peer_index_table<T: std::io::Read>(input: &mut T) -> Result<PeerIndexTable, ParserError> {
-    let collector_bgp_id = input.read_32b()?;
+    let collector_bgp_id = Ipv4Addr::from(input.read_32b()?);
     // read and ignore view name
     let view_name_length = input.read_16b()?;
     let mut buffer = Vec::new();
@@ -57,7 +57,7 @@ pub fn parse_peer_index_table<T: std::io::Read>(input: &mut T) -> Result<PeerInd
             _ => AsnLength::Bits16,
         };
 
-        let peer_bgp_id = input.read_32b()?;
+        let peer_bgp_id = Ipv4Addr::from(input.read_32b()?);
         let peer_address: IpAddr = input.read_address(&afi)?;
         let peer_asn = input.read_asn(&asn_len)?;
         peers.push(Peer{


### PR DESCRIPTION
both `collector_bgp_id` and `peer_bgp_id` are now interpreted as `Ipv4Addr` instead of `u32`.