### PR TITLE
Allow core-dump; refactor NLRI parsing for add-path issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 
 *.bz2
 *.gz
+examples/debug-file.rs

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,11 @@
 use std::{convert, error::Error, fmt, io};
+use std::fmt::{Display, Formatter};
 use std::io::ErrorKind;
 
 #[derive(Debug)]
-pub enum ParserError {
-    IoError(io::Error, Option<Vec<u8>>),
-    EofError(io::Error, Option<Vec<u8>>),
+pub enum ParserErrorKind {
+    IoError(io::Error),
+    EofError(io::Error),
     RemoteIoError(String),
     EofExpected,
     ParseError(String),
@@ -14,38 +15,58 @@ pub enum ParserError {
     Unsupported(String),
 }
 
+impl Error for ParserErrorKind {}
+
+#[derive(Debug)]
+pub struct ParserError {
+    pub error: ParserErrorKind,
+    pub bytes: Option<Vec<u8>>,
+}
+
+impl Display for ParserError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error.to_string())
+    }
+}
+
 impl Error for ParserError {}
 
 /// implement Display trait for Error which satistifies the std::error::Error
 /// trait's requirement (must implement Display and Debug traits, Debug already derived)
-impl fmt::Display for ParserError {
+impl fmt::Display for ParserErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let message = match self {
-            ParserError::IoError(e, _bytes) => e.to_string(),
-            ParserError::EofError(e, _) => e.to_string(),
-            ParserError::ParseError(s) => s.to_owned(),
-            ParserError::TruncatedMsg(s) => s.to_owned(),
-            ParserError::Deprecated(s) => s.to_owned(),
-            ParserError::UnknownAttr(s) => s.to_owned(),
-            ParserError::Unsupported(s) => s.to_owned(),
-            ParserError::EofExpected => "reach end of file".to_string(),
-            ParserError::RemoteIoError(e) => e.to_string()
+            ParserErrorKind::IoError(e) => e.to_string(),
+            ParserErrorKind::EofError(e) => e.to_string(),
+            ParserErrorKind::ParseError(s) => s.to_owned(),
+            ParserErrorKind::TruncatedMsg(s) => s.to_owned(),
+            ParserErrorKind::Deprecated(s) => s.to_owned(),
+            ParserErrorKind::UnknownAttr(s) => s.to_owned(),
+            ParserErrorKind::Unsupported(s) => s.to_owned(),
+            ParserErrorKind::EofExpected => "reach end of file".to_string(),
+            ParserErrorKind::RemoteIoError(e) => e.to_string()
         };
         write!(f, "Error: {}", message)
     }
 }
 
-impl convert::From<reqwest::Error> for ParserError {
+impl convert::From<reqwest::Error> for ParserErrorKind {
     fn from(error: reqwest::Error) -> Self {
-        ParserError::RemoteIoError(error.to_string())
+        ParserErrorKind::RemoteIoError(error.to_string())
     }
 }
 
-impl convert::From<io::Error> for ParserError {
+impl convert::From<ParserErrorKind> for ParserError {
+    fn from(error: ParserErrorKind) -> Self {
+        ParserError{error, bytes: None}
+    }
+}
+
+impl convert::From<io::Error> for ParserErrorKind {
     fn from(io_error: io::Error) -> Self {
         match io_error.kind() {
-            ErrorKind::UnexpectedEof => {ParserError::EofError(io_error, None)}
-            _ => ParserError::IoError(io_error, None)
+            ErrorKind::UnexpectedEof => { ParserErrorKind::EofError(io_error)}
+            _ => ParserErrorKind::IoError(io_error)
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -45,7 +45,7 @@ mod tests {
         let url = "http://archive.routeviews.org/route-views.sydney/bgpdata/2021.12/UPDATES/updates.20211205.0430.bz2";
         let parser = BgpkitParser::new(url).unwrap();
         let elem_count = parser.into_elem_iter().count();
-        assert_eq!(elem_count, 97770);
+        assert_eq!(elem_count, 100676);
     }
 
     #[test]
@@ -53,7 +53,7 @@ mod tests {
         let url = "http://data.ris.ripe.net/rrc23/2021.12/updates.20211205.0450.gz";
         let parser = BgpkitParser::new(url).unwrap();
         let elem_count = parser.into_elem_iter().count();
-        assert_eq!(elem_count, 41819);
+        assert_eq!(elem_count, 43532);
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,10 +3,10 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
-use crate::ParserError;
+use crate::ParserErrorKind;
 
 /// create a [BufReader] on heap from a given path to a file, located locally or remotely.
-pub(crate) fn get_reader(path: &str) -> Result<Box<dyn Read>, ParserError> {
+pub(crate) fn get_reader(path: &str) -> Result<Box<dyn Read>, ParserErrorKind> {
     // create reader for reading raw content from local or remote source, bytes can be compressed
     let raw_reader: Box<dyn Read> = match path.starts_with("http") {
         true => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ mod io;
 
 pub use parser::BgpkitParser;
 pub use parser::BgpElem;
-pub use parser::ParserError;
+pub use parser::ParserErrorKind;
 pub use parser::Elementor;
 pub use parser::iters::{ElemIterator, RecordIterator};
 pub use parser::bmp::parse_openbmp_msg;

--- a/src/parser/bmp/error.rs
+++ b/src/parser/bmp/error.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use crate::ParserError;
+use crate::ParserErrorKind;
 
 #[derive(Debug)]
 pub enum ParserBmpError {
@@ -37,8 +37,8 @@ impl std::convert::From<std::io::Error> for ParserBmpError {
     }
 }
 
-impl std::convert::From<ParserError> for ParserBmpError {
-    fn from(_: ParserError) -> Self {
+impl std::convert::From<ParserErrorKind> for ParserBmpError {
+    fn from(_: ParserErrorKind) -> Self {
         ParserBmpError::CorruptedBmpMessage
     }
 }

--- a/src/parser/iters.rs
+++ b/src/parser/iters.rs
@@ -55,8 +55,9 @@ impl Iterator for RecordIterator {
             },
             Err(e) => {
                 match e.error {
-                    ParserErrorKind::TruncatedMsg(_)| ParserErrorKind::Unsupported(_)
-                    | ParserErrorKind::UnknownAttr(_) | ParserErrorKind::Deprecated(_) => {
+                    ParserErrorKind::TruncatedMsg(e)| ParserErrorKind::Unsupported(e)
+                    | ParserErrorKind::UnknownAttr(e) | ParserErrorKind::Deprecated(e) => {
+                        warn!("Parsing error: {}", e);
                         self.next()
                     }
                     ParserErrorKind::ParseError(err_str) => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,13 +13,14 @@ pub(crate) use self::utils::*;
 pub(crate) use bgp::attributes::AttributeParser;
 pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message, parse_mrt_record, };
 
-pub use crate::error::ParserError;
+pub use crate::error::{ParserError, ParserErrorKind};
 pub use mrt::mrt_elem::Elementor;
 pub use bgp_models::prelude::{BgpElem, ElemType};
 use crate::io::get_reader;
 
 pub struct BgpkitParser {
-    reader: Box<dyn Read>
+    reader: Box<dyn Read>,
+    core_dump: bool,
 }
 
 impl BgpkitParser {
@@ -28,9 +29,17 @@ impl BgpkitParser {
         let reader = get_reader(path)?;
         Ok(
             BgpkitParser{
-                reader
+                reader,
+                core_dump: false
             }
         )
+    }
+
+    pub fn enable_core_dump(self) -> BgpkitParser {
+        BgpkitParser{
+            reader: self.reader,
+            core_dump: true
+        }
     }
 
     /// This is used in for loop `for item in parser{}`

--- a/src/parser/mrt/messages/table_dump_message.rs
+++ b/src/parser/mrt/messages/table_dump_message.rs
@@ -11,13 +11,13 @@ use bgp_models::network::{AddrMeta, Afi, AsnLength, NetworkPrefix};
 use crate::parser::bgp::attributes::AttributeParser;
 
 /// TABLE_DUMP v1 only support 2-byte asn
-fn parse_sub_type(sub_type: u16) -> Result<AddrMeta, ParserError> {
+fn parse_sub_type(sub_type: u16) -> Result<AddrMeta, ParserErrorKind> {
     let asn_len = AsnLength::Bits16;
     let afi = match sub_type {
         1 => Afi::Ipv4,
         2 => Afi::Ipv6,
         _ => {
-            return Err(ParserError::ParseError(format!(
+            return Err(ParserErrorKind::ParseError(format!(
                 "Invalid subtype found for TABLE_DUMP (V1) message: {}",
                 sub_type
             )))
@@ -47,7 +47,7 @@ fn parse_sub_type(sub_type: u16) -> Result<AddrMeta, ParserError> {
 pub fn parse_table_dump_message<T: Read>(
     sub_type: u16,
     input: &mut T,
-) -> Result<TableDumpMessage, ParserError> {
+) -> Result<TableDumpMessage, ParserErrorKind> {
     let meta = parse_sub_type(sub_type)?;
 
     let view_number = input.read_u16::<BigEndian>()?;

--- a/src/parser/mrt/messages/table_dump_v2_message.rs
+++ b/src/parser/mrt/messages/table_dump_v2_message.rs
@@ -123,7 +123,7 @@ pub fn parse_rib_afi_entries<T: std::io::Read>(input: &mut Take<T>, rib_type: Ta
 
     let sequence_number = input.read_32b()?;
 
-    let prefix = input.read_nlri_prefix(&afi, 0)?;
+    let prefix = input.read_nlri_prefix(&afi, add_path)?;
     let prefixes = vec!(prefix.clone());
 
     let entry_count = input.read_16b()?;

--- a/src/parser/mrt/messages/table_dump_v2_message.rs
+++ b/src/parser/mrt/messages/table_dump_v2_message.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use crate::error::ParserError;
+use crate::error::ParserErrorKind;
 use std::io::{Read, Take};
 use std::net::{IpAddr, Ipv4Addr};
 use bgp_models::mrt::tabledump::{Peer, PeerIndexTable, RibAfiEntries, RibEntry, TableDumpV2Message, TableDumpV2Type};
@@ -9,10 +9,10 @@ use crate::parser::{AttributeParser, ReadUtils};
 
 pub fn parse_table_dump_v2_message<T: Read>(
     sub_type: u16,
-    input: &mut Take<T>) -> Result<TableDumpV2Message, ParserError> {
+    input: &mut Take<T>) -> Result<TableDumpV2Message, ParserErrorKind> {
     let v2_type: TableDumpV2Type = match TableDumpV2Type::from_u16(sub_type) {
         Some(t) => t,
-        None => {return Err(ParserError::ParseError(format!("cannot parse table dump v2 type: {}", sub_type)))}
+        None => {return Err(ParserErrorKind::ParseError(format!("cannot parse table dump v2 type: {}", sub_type)))}
     };
 
     let msg: TableDumpV2Message = match v2_type {
@@ -26,7 +26,7 @@ pub fn parse_table_dump_v2_message<T: Read>(
             TableDumpV2Message::RibAfiEntries(parse_rib_afi_entries(input, v2_type)?)
         },
         TableDumpV2Type::RibGeneric| TableDumpV2Type::RibGenericAddPath| TableDumpV2Type::GeoPeerTable => {
-            return Err(ParserError::Unsupported("TableDumpV2 RibGeneric and GeoPeerTable is not currently supported".to_string()))
+            return Err(ParserErrorKind::Unsupported("TableDumpV2 RibGeneric and GeoPeerTable is not currently supported".to_string()))
         }
     };
 
@@ -36,7 +36,7 @@ pub fn parse_table_dump_v2_message<T: Read>(
 /// Peer index table
 ///
 /// https://tools.ietf.org/html/rfc6396#section-4.3
-pub fn parse_peer_index_table<T: std::io::Read>(input: &mut T) -> Result<PeerIndexTable, ParserError> {
+pub fn parse_peer_index_table<T: std::io::Read>(input: &mut T) -> Result<PeerIndexTable, ParserErrorKind> {
     let collector_bgp_id = Ipv4Addr::from(input.read_32b()?);
     // read and ignore view name
     let view_name_length = input.read_16b()?;
@@ -88,7 +88,7 @@ pub fn parse_peer_index_table<T: std::io::Read>(input: &mut T) -> Result<PeerInd
 /// RIB AFI-specific entries
 ///
 /// https://tools.ietf.org/html/rfc6396#section-4.3
-pub fn parse_rib_afi_entries<T: std::io::Read>(input: &mut Take<T>, rib_type: TableDumpV2Type) -> Result<RibAfiEntries, ParserError> {
+pub fn parse_rib_afi_entries<T: std::io::Read>(input: &mut Take<T>, rib_type: TableDumpV2Type) -> Result<RibAfiEntries, ParserErrorKind> {
     let afi: Afi;
     let safi: Safi;
     match rib_type {
@@ -109,7 +109,7 @@ pub fn parse_rib_afi_entries<T: std::io::Read>(input: &mut Take<T>, rib_type: Ta
             safi = Safi::Multicast
         }
         _ => {
-            return Err(ParserError::ParseError(format!("wrong RIB type for parsing: {:?}", rib_type)))
+            return Err(ParserErrorKind::ParseError(format!("wrong RIB type for parsing: {:?}", rib_type)))
         }
     };
 
@@ -151,9 +151,9 @@ pub fn parse_rib_afi_entries<T: std::io::Read>(input: &mut Take<T>, rib_type: Ta
     )
 }
 
-pub fn parse_rib_entry<T: std::io::Read>(input: &mut Take<T>, add_path: bool, afi: &Afi, safi: &Safi, prefixes: &Vec<NetworkPrefix>) -> Result<RibEntry, ParserError> {
+pub fn parse_rib_entry<T: std::io::Read>(input: &mut Take<T>, add_path: bool, afi: &Afi, safi: &Safi, prefixes: &Vec<NetworkPrefix>) -> Result<RibEntry, ParserErrorKind> {
     if input.limit() < 16 {
-        return Err(ParserError::TruncatedMsg(format!("truncated msg")))
+        return Err(ParserErrorKind::TruncatedMsg(format!("truncated msg")))
     }
     let peer_index = input.read_16b()?;
     let originated_time = input.read_32b()?;
@@ -163,7 +163,7 @@ pub fn parse_rib_entry<T: std::io::Read>(input: &mut Take<T>, add_path: bool, af
     let attribute_length = input.read_16b()?;
 
     if input.limit() < attribute_length as u64 {
-        return Err(ParserError::TruncatedMsg(format!("truncated msg")))
+        return Err(ParserErrorKind::TruncatedMsg(format!("truncated msg")))
     }
 
     let attr_parser = AttributeParser::new(add_path);


### PR DESCRIPTION
This PR enables parsing of NLRI block with potentially wrong
add-path type. In some cases, the BGP message with add-path might be
wrapped in a non-add-path message and causing trouble parsing NLRI block
in BGP message and in attributes.

This patch implements a workaround that can more intelligently "guess"
the add-path intention and revert back to regular parsing when guess
fails. Here is a brief description of the workaround:

- If add-path is not set (i.e. not the add-path BGP msgs) and the first
byte of an NLRI entry is 0, it is likely an add-path msg wrapped in
non-add-path msg, treat as add-path. This covers both IPv4 and IPv6
cases.
- If an error happens when parsing, revert back to the original add-path
setting (this only happens for `0.0.0.0/0` or `0::/0` prefixes without
add-path, which is pretty rare) and re-parse the whole NLRI
block. (needs to go back a few bytes to the beginning).
- The unhandled cases are the ones where the first byte of path_id is
not zero. In those cases, we will, unfortunately, parse the msg without
path-id, and depending on the msg, we might see parsing errors
later (e.g. not enough bytes, or extra bytes).

Test run show that the parsing of one problematic file is resolved back
to normal now. See #31 for
more details.