### PR TITLE
add filtering and iterator support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ ipnetwork = {version="0.18", default-features=false}
 enum-primitive-derive = "0.2"
 num-traits = "0.1"
 chrono = "0.4"
-bgp-models = "0.6.1"
+bgp-models = "0.6.2"
+regex = "1"
 
 # logging
 log="0.4"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,36 @@ fn main(){
     }
 }
 ```
+
+
+### Filtering BGP Messages
+
+BGPKIT Parser also has built-in filtering mechanism. When creating a new BgpkitParser instance,
+once can also call `add_filter` function to customize the parser to only show matching messages
+when iterating through BgpElems.
+
+```no_run
+use bgpkit_parser::BgpkitParser;
+
+/// This example shows how to parse a MRT file and filter by prefix.
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    log::info!("downloading updates file");
+
+    // create a parser that takes the buffered reader
+    let parser = BgpkitParser::new("http://archive.routeviews.org/bgpdata/2021.10/UPDATES/updates.20211001.0000.bz2").unwrap()
+        .add_filter("prefix", "211.98.251.0/24").unwrap();
+
+    log::info!("parsing updates file");
+    // iterating through the parser. the iterator returns `BgpElem` one at a time.
+    for elem in parser {
+        log::info!("{}", &elem);
+    }
+    log::info!("done");
+}
+```
+
 ### Parsing Real-time Data Streams
 
 BGPKIT Parser also provides parsing functionalities for real-time data streams, including [RIS-Live][ris-live-url]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # BGPKIT Parser
+
 [![Rust](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml/badge.svg)](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/bgpkit-parser)](https://crates.io/crates/bgpkit-parser)
+[![Docs.rs](https://docs.rs/bgpkit-parser/badge.svg)](https://docs.rs/bgpkit-parser)
+[![License](https://img.shields.io/crates/l/bgpkit-parser)](https://raw.githubusercontent.com/bgpkit/bgpkit-parser/master/LICENSE)
+![Discord](https://img.shields.io/discord/919618842613927977?label=discord&style=plastic)
+![Crates.io](https://img.shields.io/crates/d/bgpkit-parser)
 
 BGPKIT Parser aims to provides the most ergonomic MRT/BGP/BMP message parsing Rust API.
 

--- a/benches/download.sh
+++ b/benches/download.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 RIB_LOCAL=/tmp/rib-example.bz2
-RIB_REMOTE=https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/rib-example.bz2
+RIB_REMOTE=https://spaces.bgpkit.org/parser/rib-example.bz2
 
 UPD_LOCAL=/tmp/update-example.gz
-UPD_REMOTE=https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example.gz
+UPD_REMOTE=https://spaces.bgpkit.org/parser/update-example.gz
 
 if test -f "$RIB_LOCAL"; then
     echo "rib file already exist: $RIB_LOCAL"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,3 +19,4 @@ serde="1.0"
 serde_json = "1.0"
 structopt = "0.3"
 bgpkit-parser = {path=".."}
+ipnetwork = {version="0.18", default-features=false}

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,18 +12,25 @@ Mingwei Zhang <mingwei@bgpkit.com>
 bgpkit-parser-cli is a simple cli tool that allow parsing of individual MRT files
 
 USAGE:
-    bgpkit-parser-cli [OPTIONS] <FILE>
+    bgpkit-parser-cli [FLAGS] [OPTIONS] <FILE>
 
-ARGS:
-    <FILE>    File path to an MRT file, local or remote
+FLAGS:
+    -e, --elems-count      Count BGP elems
+    -h, --help             Prints help information
+        --json             Output as JSON objects
+        --pretty           Pretty-print JSON output
+    -r, --records-count    Count MRT records
+    -V, --version          Prints version information
 
 OPTIONS:
-    -e, --elems-count      Count BGP elems
-    -h, --help             Print help information
-    -j, --json             Output as JSON objects
-    -p, --pretty           Pretty-print JSON output
-    -r, --records-count    Count MRT records
-    -V, --version          Print version information
+    -a, --as-path <as-path>          Filter by AS path regex string
+    -m, --elem-type <elem-type>      Filter by elem type: announce (a) or withdraw (w)
+    -T, --end-ts <end-ts>            Filter by end unix timestamp inclusive
+    -o, --origin-asn <origin-asn>    Filter by origin AS Number
+    -J, --peer-asn <peer-asn>        Filter by peer IP ASN
+    -j, --peer-ip <peer-ip>          Filter by peer IP address
+    -p, --prefix <prefix>            Filter by network prefix
+    -t, --start-ts <start-ts>        Filter by start unix timestamp inclusive
 ```
 
 ## Examples
@@ -36,13 +43,7 @@ A|1637437799|185.1.8.65|60924|186.233.208.0/22|60924 6939 57463 271253 271253 26
 A|1637437799|185.1.8.65|60924|186.233.208.0/21|60924 6939 57463 271253 271253 264556 262873 262793|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
 A|1637437799|185.1.8.65|60924|143.137.53.0/24|60924 6939 57463 271253 271253 264556 262873 264031|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
 A|1637437799|2001:7f8:73::edfc:0:2|60924|2607:fdf0:5e54::/48|60924 59605 6453 1299 13807 8008|IGP||0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|2001:7f8:73::edfc:0:2|60924|2a0f:ca80:1::/48|60924 59605 9002 207083 208046|IGP||0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|2001:7f8:73::edfc:0:2|60924|2a0f:ca86::/40|60924 59605 9002 207083 208046|IGP||0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|185.1.8.65|60924|143.137.52.0/24|60924 6939 57463 271253 271253 264556 264031|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|185.1.8.65|60924|177.53.206.0/24|60924 6939 57463 271253 271253 264556 262873 262483|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|185.1.8.65|60924|177.53.207.0/24|60924 6939 57463 271253 271253 264556 262873 262483|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-A|1637437799|185.1.8.65|60924|177.53.206.0/23|60924 6939 57463 271253 271253 264556 262873 262483|IGP|185.1.8.63|0|0|60924:6 60924:150 60924:502 60924:2002|NAG||
-
+...
 ```
 
 ### Parse remote file
@@ -53,12 +54,7 @@ A|1638040499.820021|103.151.196.1|140684|103.139.144.0/24|58689 139192|IGP|103.1
 A|1638040499.842529|103.151.196.1|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.88|0|0||NAG||
 A|1638040499.842567|103.151.196.5|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.88|0|0||NAG||
 A|1638040500.212436|103.151.196.1|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.177|0|0||NAG||
-A|1638040500.212538|103.151.196.5|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.177|0|0||NAG||
-A|1638040500.298756|103.151.196.5|140684|103.139.144.0/24|23956 58689 139192|IGP|103.151.196.88|0|0||NAG||
-A|1638040500.299005|103.151.196.1|140684|103.139.144.0/24|134146 134146 134146 134146 58689 139192|IGP|103.151.196.183|0|4||NAG||
-A|1638040500.357723|103.151.196.1|140684|103.139.144.0/24|134146 134146 134146 134146 23956 58689 139192|IGP|103.151.196.183|0|4||NAG||
-A|1638040500.384225|103.151.196.1|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.88|0|0||NAG||
-A|1638040500.384266|103.151.196.5|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.88|0|0||NAG||
+...
 ```
 
 ### Count file's MRT records and BGP messages
@@ -69,3 +65,37 @@ total records: 15678
 total elems:   15722
 ```
 
+### Use filters
+
+Available filters are:
+```text
+    -a, --as-path <as-path>          Filter by AS path regex string
+    -m, --elem-type <elem-type>      Filter by elem type: announce (a) or withdraw (w)
+    -o, --origin-asn <origin-asn>    Filter by origin AS Number
+    -J, --peer-asn <peer-asn>        Filter by peer IP ASN
+    -j, --peer-ip <peer-ip>          Filter by peer IP address
+    -p, --prefix <prefix>            Filter by network prefix
+    -t, --start-ts <start-ts>        Filter by start unix timestamp inclusive
+    -T, --end-ts <end-ts>            Filter by end unix timestamp inclusive
+```
+
+For example, filter by peer IP address:
+```
+bgpkit-parser-cli http://archive.routeviews.org/route-views.bdix/bgpdata/2021.11/UPDATES/updates.20211127.1900.bz2 --peer-ip 103.151.196.1
+A|1638039600.519347|103.151.196.1|140684|103.139.144.0/24|58689 139192|IGP|103.151.196.177|0|0||NAG||
+A|1638039600.570541|103.151.196.1|140684|103.139.144.0/24|134146 134146 134146 134146 58689 139192|IGP|103.151.196.183|0|4||NAG||
+W|1638039600.588036|103.151.196.1|140684|103.139.144.0/24|||||||||
+A|1638039600.635757|103.151.196.1|140684|103.139.144.0/24|134146 134146 134146 134146 23956 58689 139192|IGP|103.151.196.183|0|4||NAG||
+...
+```
+
+Multiple filters can be used to construct a combination of filters.
+For example, filter by peer IP address and keep only the withdraws:
+```
+bgpkit-parser-cli http://archive.routeviews.org/route-views.bdix/bgpdata/2021.11/UPDATES/updates.20211127.1900.bz2 --peer-ip 103.151.196.1 --elem-type w |head
+W|1638039600.588036|103.151.196.1|140684|103.139.144.0/24|||||||||
+W|1638039600.909854|103.151.196.1|140684|103.139.144.0/24|||||||||
+W|1638039601.908543|103.151.196.1|140684|103.139.144.0/24|||||||||
+W|1638039602.266345|103.151.196.1|140684|103.139.144.0/24|||||||||
+...
+```

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -1,0 +1,35 @@
+use bgpkit_parser::BgpkitParser;
+
+/// This example shows how to parse a MRT file and filter by prefix.
+///
+/// The corresponding command line execution is:
+/// ```text
+/// $ bgpkit-parser-cli http://archive.routeviews.org/bgpdata/2021.10/UPDATES/updates.20211001.0000.bz2 --prefix 211.98.251.0/24
+/// A|1633046459.372282|168.209.255.56|3741|211.98.251.0/24|3741 3356 58453 9808 9394|IGP|168.209.255.56|0|0||NAG||
+/// A|1633046473.592947|168.209.255.56|3741|211.98.251.0/24|3741 3356 58453 9808 9394|IGP|168.209.255.56|0|0||NAG||
+/// ```
+///
+/// The expected output of this example is (log's timestamp will be different):
+/// ```text
+/// [2021-12-11T02:45:25Z INFO  filters] downloading updates file
+/// [2021-12-11T02:45:25Z INFO  filters] parsing updates file
+/// [2021-12-11T02:45:26Z INFO  filters] A|1633046459.372282|168.209.255.56|3741|211.98.251.0/24|3741 3356 58453 9808 9394|IGP|168.209.255.56|0|0||NAG||
+/// [2021-12-11T02:45:26Z INFO  filters] A|1633046473.592947|168.209.255.56|3741|211.98.251.0/24|3741 3356 58453 9808 9394|IGP|168.209.255.56|0|0||NAG||
+/// [2021-12-11T02:45:29Z INFO  filters] done
+/// ```
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    log::info!("downloading updates file");
+
+    // create a parser that takes the buffered reader
+    let parser = BgpkitParser::new("http://archive.routeviews.org/bgpdata/2021.10/UPDATES/updates.20211001.0000.bz2").unwrap()
+        .add_filter("prefix", "211.98.251.0/24").unwrap();
+
+    log::info!("parsing updates file");
+    // iterating through the parser. the iterator returns `BgpElem` one at a time.
+    for elem in parser {
+        log::info!("{}", &elem);
+    }
+    log::info!("done");
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum ParserErrorKind {
     TruncatedMsg(String),
     Deprecated(String),
     Unsupported(String),
+    FilterError(String),
 }
 
 impl Error for ParserErrorKind {}
@@ -44,7 +45,8 @@ impl fmt::Display for ParserErrorKind {
             ParserErrorKind::UnknownAttr(s) => s.to_owned(),
             ParserErrorKind::Unsupported(s) => s.to_owned(),
             ParserErrorKind::EofExpected => "reach end of file".to_string(),
-            ParserErrorKind::RemoteIoError(e) => e.to_string()
+            ParserErrorKind::RemoteIoError(e) => e.to_string(),
+            ParserErrorKind::FilterError(e) => e.to_owned(),
         };
         write!(f, "Error: {}", message)
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_remote_uncompressed() {
-        let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
+        let url = "https://spaces.bgpkit.org/parser/update-example";
         let parser = BgpkitParser::new(url).unwrap();
         let elem_count = parser.into_elem_iter().count();
         assert_eq!(elem_count, 8160);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,37 @@ fn main(){
 }
 ```
 
+### Filtering BGP Messages
+
+BGPKIT Parser also has built-in [Filter] mechanism. When creating a new [BgpkitParser] instance,
+once can also call `add_filter` function to customize the parser to only show matching messages
+when iterating through [BgpElem]s.
+
+For all types of filters, check out the [Filter] enum documentation.
+
+```no_run
+use bgpkit_parser::BgpkitParser;
+
+/// This example shows how to parse a MRT file and filter by prefix.
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    log::info!("downloading updates file");
+
+    // create a parser that takes the buffered reader
+    let parser = BgpkitParser::new("http://archive.routeviews.org/bgpdata/2021.10/UPDATES/updates.20211001.0000.bz2").unwrap()
+        .add_filter("prefix", "211.98.251.0/24").unwrap();
+
+    log::info!("parsing updates file");
+    // iterating through the parser. the iterator returns `BgpElem` one at a time.
+    for elem in parser {
+        log::info!("{}", &elem);
+    }
+    log::info!("done");
+}
+```
+
+
 ### Parsing Real-time Data Streams
 
 BGPKIT Parser also provides parsing functionalities for real-time data streams, including [RIS-Live][ris-live-url]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,3 +308,4 @@ pub use parser::bmp::parse_openbmp_msg;
 pub use parser::bmp::parse_bmp_msg;
 pub use parser::bmp::parse_openbmp_header;
 pub use parser::rislive::parse_ris_live_message;
+pub use parser::filter::*;

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -198,8 +198,10 @@ mod tests {
     #[test]
     fn test_filter_iter() {
         let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
-        let parser = BgpkitParser::new(url).unwrap().add_filter("type", "w").unwrap();
+        let parser = BgpkitParser::new(url).unwrap()
+            .add_filter("peer_ip", "185.1.8.50").unwrap()
+            .add_filter("type", "w").unwrap();
         let count = parser.into_elem_iter().count();
-        assert_eq!(count, 379);
+        assert_eq!(count, 39);
     }
 }

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_filter() {
-        let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
+        let url = "https://spaces.bgpkit.org/parser/update-example.gz";
         let parser = BgpkitParser::new(url).unwrap();
         let elems = parser.into_elem_iter().collect::<Vec<BgpElem>>();
 
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_filter_iter() {
-        let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
+        let url = "https://spaces.bgpkit.org/parser/update-example.gz";
         let parser = BgpkitParser::new(url).unwrap()
             .add_filter("peer_ip", "185.1.8.50").unwrap()
             .add_filter("type", "w").unwrap();

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -1,0 +1,205 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+use bgp_models::prelude::*;
+use ipnetwork::IpNetwork;
+use regex::Regex;
+use crate::ParserErrorKind;
+use crate::ParserErrorKind::FilterError;
+
+pub enum Filter {
+    OriginAsn(Asn),
+    Prefix(IpNetwork),
+    PeerIp(IpAddr),
+    PeerAsn(Asn),
+    Type(ElemType),
+    TsStart(f64),
+    TsEnd(f64),
+    Path(Regex),
+}
+
+impl Filter {
+    pub fn new(filter_type: &str, filter_value: &str) -> Result<Filter, ParserErrorKind> {
+        match filter_type {
+            "origin_asn" => {
+                match u32::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::OriginAsn(v))},
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse origin asn from {}", filter_value)))
+                    }
+                }
+            }
+            "prefix" => {
+                match IpNetwork::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::Prefix(v))}
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse prefix from {}", filter_value)))
+                    }
+                }
+            }
+            "peer_ip" => {
+                match IpAddr::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::PeerIp(v))}
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse peer IP from {}", filter_value)))
+                    }
+                }
+            }
+            "peer_asn" => {
+                match u32::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::PeerAsn(v))},
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse peer asn from {}", filter_value)))
+                    }
+                }
+            }
+            "type" => {
+                match filter_value {
+                    "w"|"withdraw"|"withdrawal" => {
+                        Ok(Filter::Type(ElemType::WITHDRAW))
+                    }
+                    "a"|"announce"|"announcement" => {
+                        Ok(Filter::Type(ElemType::ANNOUNCE))
+                    }
+                    _ => {
+                        Err(FilterError(format!("cannot parse elem type from {}", filter_value)))
+                    }
+                }
+            }
+            "ts_start" => {
+                match f64::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::TsStart(v))},
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse f64 value from {}", filter_value)))
+                    }
+                }
+            }
+            "ts_end" => {
+                match f64::from_str(filter_value) {
+                    Ok(v) => {Ok(Filter::TsEnd(v))},
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse f64 value from {}", filter_value)))
+                    }
+                }
+            }
+            "path" => {
+                match Regex::from_str(filter_value) {
+                    Ok(v) => {
+                        Ok(Filter::Path(v))
+                    }
+                    Err(_) => {
+                        Err(FilterError(format!("cannot parse AS path regex from {}", filter_value)))
+                    }
+                }
+            }
+            _ => {
+                Err(FilterError(format!("unknown filter type: {}", filter_type)))
+            }
+        }
+    }
+}
+
+pub trait Filterable {
+    fn match_filter(&self, filter: &Filter) -> bool;
+    fn match_filters(&self, filters: &Vec<Filter>) -> bool;
+}
+
+impl Filterable for BgpElem {
+    fn match_filter(&self, filter: &Filter) -> bool {
+        match filter {
+            Filter::OriginAsn(v) => {
+                if let Some(origins) = &self.origin_asns {
+                    origins.contains(v)
+                } else {
+                    false
+                }
+            }
+            Filter::Prefix(v) => {
+                self.prefix.to_string() == v.to_string()
+            }
+            Filter::PeerIp(v) => {
+                self.peer_ip == *v
+            }
+            Filter::PeerAsn(v) => {
+                self.peer_asn == *v
+            }
+            Filter::Type(v) => {
+                self.elem_type == *v
+            }
+            Filter::TsStart(v) => {
+                self.timestamp >= *v
+            }
+            Filter::TsEnd(v) => {
+                self.timestamp <= *v
+            }
+            Filter::Path(v) => {
+                if let Some(path) = &self.as_path {
+                    v.is_match(path.to_string().as_str())
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn match_filters(&self, filters: &Vec<Filter>) -> bool {
+        filters.iter().all(|f| {
+            self.match_filter(f)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use crate::BgpkitParser;
+    use super::*;
+
+    #[test]
+    fn test_filter() {
+        let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
+        let parser = BgpkitParser::new(url).unwrap();
+        let elems = parser.into_elem_iter().collect::<Vec<BgpElem>>();
+
+        let mut filters = vec![];
+        filters.push(Filter::PeerIp(IpAddr::from_str("185.1.8.65").unwrap()));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 3393);
+
+        let mut filters = vec![];
+        filters.push(Filter::PeerIp(IpAddr::from_str("185.1.8.65").unwrap()));
+        filters.push(Filter::Prefix(IpNetwork::from_str("190.115.192.0/22").unwrap()));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 5);
+
+        let mut filters = vec![];
+        let regex = Regex::new(r" ?174 1916 52888$").unwrap();
+        filters.push(Filter::Path(regex));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 12);
+
+        let mut filters = vec![];
+        filters.push(Filter::TsStart(1637437798 as f64));
+        filters.push(Filter::TsEnd(1637437798 as f64));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 13);
+
+        let mut filters = vec![];
+        filters.push(Filter::Type(ElemType::WITHDRAW));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 379);
+
+        let mut filters = vec![];
+        filters.push(Filter::Type(ElemType::WITHDRAW));
+        filters.push(Filter::Prefix(IpNetwork::from_str("2804:100::/32").unwrap()));
+        let count = elems.iter().filter(|e| e.match_filters(&filters)).count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_filter_iter() {
+        let url = "https://bgpkit-data.sfo3.digitaloceanspaces.com/parser/update-example";
+        let parser = BgpkitParser::new(url).unwrap().add_filter("type", "w").unwrap();
+        let count = parser.into_elem_iter().count();
+        assert_eq!(count, 379);
+    }
+}

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -65,7 +65,7 @@ impl Filter {
                     }
                 }
             }
-            "ts_start" => {
+            "start_ts" => {
                 match f64::from_str(filter_value) {
                     Ok(v) => {Ok(Filter::TsStart(v))},
                     Err(_) => {
@@ -73,7 +73,7 @@ impl Filter {
                     }
                 }
             }
-            "ts_end" => {
+            "end_ts" => {
                 match f64::from_str(filter_value) {
                     Ok(v) => {Ok(Filter::TsEnd(v))},
                     Err(_) => {
@@ -81,7 +81,7 @@ impl Filter {
                     }
                 }
             }
-            "path" => {
+            "as_path" => {
                 match Regex::from_str(filter_value) {
                     Ok(v) => {
                         Ok(Filter::Path(v))

--- a/src/parser/iters.rs
+++ b/src/parser/iters.rs
@@ -6,6 +6,7 @@ use bgp_models::mrt::MrtRecord;
 use crate::{BgpElem, Elementor};
 use crate::error::ParserErrorKind;
 use crate::parser::BgpkitParser;
+use crate::Filterable;
 
 /// Use [BgpElemIterator] as the default iterator to return [BgpElem]s instead of [MrtRecord]s.
 impl IntoIterator for BgpkitParser {
@@ -31,8 +32,8 @@ MrtRecord Iterator
 **********/
 
 pub struct RecordIterator {
-    parser: BgpkitParser,
-    count: u64,
+    pub parser: BgpkitParser,
+    pub count: u64,
 }
 
 impl RecordIterator {
@@ -85,7 +86,7 @@ impl Iterator for RecordIterator {
                         }
                         None
                     }
-                    ParserErrorKind::RemoteIoError(_) => {
+                    ParserErrorKind::RemoteIoError(_) | ParserErrorKind::FilterError(_)=> {
                         // this should not happen at this stage
                         None
                     }
@@ -142,11 +143,18 @@ impl Iterator for ElemIterator {
             // when reaching here, the `self.cache_elems` has been refilled with some more elems
         }
 
-        // poping cached elems. note that the original elems order is preseved by reversing the
+        // popping cached elems. note that the original elems order is preseved by reversing the
         // vector before putting it on to cache_elems.
-        match self.cache_elems.pop() {
+        let elem = match self.cache_elems.pop() {
             None => {None}
-            Some(i) => {Some(i) }
+            Some(i) => {Some(i)}
+        };
+        match elem {
+            None => None,
+            Some(e) => match e.match_filters(&self.record_iter.parser.filters) {
+                true => {Some(e)}
+                false => {self.next()}
+            }
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -53,7 +53,7 @@ impl BgpkitParser {
         Ok(
             BgpkitParser {
                 reader: self.reader,
-                core_dump: true,
+                core_dump: self.core_dump,
                 filters
             }
         )

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,6 +8,7 @@ pub mod bmp;
 pub mod bgp;
 pub mod iters;
 pub mod rislive;
+pub mod filter;
 
 pub(crate) use self::utils::*;
 pub(crate) use bgp::attributes::AttributeParser;
@@ -16,11 +17,13 @@ pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2
 pub use crate::error::{ParserError, ParserErrorKind};
 pub use mrt::mrt_elem::Elementor;
 pub use bgp_models::prelude::{BgpElem, ElemType};
+use crate::Filter;
 use crate::io::get_reader;
 
 pub struct BgpkitParser {
     reader: Box<dyn Read>,
     core_dump: bool,
+    filters: Vec<Filter>
 }
 
 impl BgpkitParser {
@@ -30,7 +33,8 @@ impl BgpkitParser {
         Ok(
             BgpkitParser{
                 reader,
-                core_dump: false
+                core_dump: false,
+                filters: vec![]
             }
         )
     }
@@ -38,8 +42,21 @@ impl BgpkitParser {
     pub fn enable_core_dump(self) -> BgpkitParser {
         BgpkitParser{
             reader: self.reader,
-            core_dump: true
+            core_dump: true,
+            filters: vec![]
         }
+    }
+
+    pub fn add_filter(self, filter_type: &str, filter_value: &str) -> Result<BgpkitParser, ParserError> {
+        let mut filters = self.filters;
+        filters.push(Filter::new(filter_type, filter_value)?);
+        Ok(
+            BgpkitParser {
+                reader: self.reader,
+                core_dump: true,
+                filters
+            }
+        )
     }
 
     /// This is used in for loop `for item in parser{}`


### PR DESCRIPTION
Filtering features (added in https://github.com/bgpkit/bgpkit-parser/commit/b2f2b50a49def49ee51ab75bcf4af8505db31949):
- [X] origin ASN
- [X] prefix
- [X] peer IP
- [X] peer asn
- [X] msg type (announce, withdraw)
- [X] timestamp start
- [X] timestamp end
- [X] as path


Other features:
- [x] `bgpkit-parser-cli` support (added in https://github.com/bgpkit/bgpkit-parser/commit/85bd9495f1c1e3617c45a990df3c4072cdff549c)
- [x] add example
- [x] add documentation
- [x] add screencast for using filters with cli
