### PR TITLE
remove unnecessary dbg! calls in code

### DIFF
--- a/src/parser/bgp/attributes.rs
+++ b/src/parser/bgp/attributes.rs
@@ -331,8 +331,6 @@ impl AttributeParser {
             next_hop = match self.parse_mp_next_hop(next_hop_length, input) {
                 Ok(x) => x,
                 Err(e) => {
-                    dbg!(&e);
-                    dbg!(&afi);
                     return Err(e)
                 }
             };

--- a/src/parser/mrt/messages/table_dump_v2_message.rs
+++ b/src/parser/mrt/messages/table_dump_v2_message.rs
@@ -133,7 +133,6 @@ pub fn parse_rib_afi_entries(input: &mut DataBytes, rib_type: TableDumpV2Type) -
             Ok(entry) => entry,
             Err(e) => return Err(e)
         };
-        // dbg!(&entry, &rib_type);
         rib_entries.push(entry);
     }
 

--- a/src/parser/mrt/mrt_record.rs
+++ b/src/parser/mrt/mrt_record.rs
@@ -126,7 +126,6 @@ fn parse_raw_bytes(common_header: &CommonHeader, data: &mut DataBytes) -> Result
             match msg {
                 Ok(msg) => MrtMessage::TableDumpMessage(msg),
                 Err(e) => {
-                    dbg!(&e);
                     return Err(e);
                 }
             }
@@ -151,7 +150,6 @@ fn parse_raw_bytes(common_header: &CommonHeader, data: &mut DataBytes) -> Result
         }
         v => {
             // deprecated
-            dbg!(common_header);
             return Err(ParserErrorKind::Unsupported(format!("unsupported MRT type: {:?}", v)))
         }
     };


### PR DESCRIPTION
Remove unnecessary `dbg!` macro calls in code. Proper error handling should take care of that.