### PR TITLE
Introduce struct to allow configure parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgpkit-parser"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,8 @@ pub enum ParserErrorKind {
     EofExpected,
     ParseError(String),
     UnknownAttr(String),
+    DeprecatedAttr(String),
     TruncatedMsg(String),
-    Deprecated(String),
     Unsupported(String),
     FilterError(String),
 }
@@ -42,7 +42,7 @@ impl fmt::Display for ParserErrorKind {
             ParserErrorKind::EofError(e) => e.to_string(),
             ParserErrorKind::ParseError(s) => s.to_owned(),
             ParserErrorKind::TruncatedMsg(s) => s.to_owned(),
-            ParserErrorKind::Deprecated(s) => s.to_owned(),
+            ParserErrorKind::DeprecatedAttr(s) => s.to_owned(),
             ParserErrorKind::UnknownAttr(s) => s.to_owned(),
             ParserErrorKind::Unsupported(s) => s.to_owned(),
             ParserErrorKind::EofExpected => "reach end of file".to_string(),

--- a/src/parser/bgp/attributes.rs
+++ b/src/parser/bgp/attributes.rs
@@ -73,7 +73,7 @@ impl AttributeParser {
                     input.read_and_drop_n_bytes(length)?;
                     return match attr_type {
                         11 | 12 | 13 | 19 | 20 | 21 | 28 | 30 | 31 | 129 | 241..=243 => {
-                            Err(crate::error::ParserErrorKind::UnknownAttr(format!("deprecated attribute type: {}", attr_type)))
+                            Err(crate::error::ParserErrorKind::DeprecatedAttr(format!("deprecated attribute type: {}", attr_type)))
                         }
                         _ => {
                             Err(crate::error::ParserErrorKind::UnknownAttr(format!("unknown attribute type: {}", attr_type)))

--- a/src/parser/iters.rs
+++ b/src/parser/iters.rs
@@ -31,6 +31,7 @@ impl BgpkitParser {
 MrtRecord Iterator
 **********/
 
+
 pub struct RecordIterator {
     pub parser: BgpkitParser,
     pub count: u64,
@@ -81,12 +82,14 @@ impl Iterator for RecordIterator {
                 Err(e) => {
                     match e.error {
                         ParserErrorKind::TruncatedMsg(e)| ParserErrorKind::Unsupported(e)
-                        | ParserErrorKind::UnknownAttr(e) | ParserErrorKind::Deprecated(e) => {
-                            warn!("parsing error: {}", e);
+                        | ParserErrorKind::UnknownAttr(e) | ParserErrorKind::DeprecatedAttr(e) => {
+                            if self.parser.options.show_warnings {
+                                warn!("parser warn: {}", e);
+                            }
                             continue
                         }
                         ParserErrorKind::ParseError(err_str) => {
-                            warn!("parsing error: {}", err_str);
+                            error!("parser error: {}", err_str);
                             if self.parser.core_dump {
                                 if let Some(bytes) = e.bytes {
                                     std::fs::write("mrt_cord_dump", bytes).expect("Unable to write to mrt_core_dump");

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -63,9 +63,9 @@ impl BgpkitParser {
         }
     }
 
-    pub fn disable_unknown_attr_warning(self) -> BgpkitParser {
+    pub fn disable_warnings(self) -> BgpkitParser {
         let mut options = self.options;
-        options.disable_warning = true;
+        options.show_warnings = false;
         BgpkitParser{
             reader: self.reader,
             core_dump: self.core_dump,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,7 +23,19 @@ use crate::io::get_reader;
 pub struct BgpkitParser {
     reader: Box<dyn Read>,
     core_dump: bool,
-    filters: Vec<Filter>
+    filters: Vec<Filter>,
+    options: ParserOptions
+}
+
+pub(crate) struct ParserOptions {
+    show_warnings: bool
+}
+impl Default for ParserOptions {
+    fn default() -> Self {
+        ParserOptions{
+            show_warnings: true
+        }
+    }
 }
 
 unsafe impl Send for BgpkitParser {}
@@ -36,7 +48,8 @@ impl BgpkitParser {
             BgpkitParser{
                 reader,
                 core_dump: false,
-                filters: vec![]
+                filters: vec![],
+                options: ParserOptions::default()
             }
         )
     }
@@ -45,7 +58,19 @@ impl BgpkitParser {
         BgpkitParser{
             reader: self.reader,
             core_dump: true,
-            filters: vec![]
+            filters: self.filters,
+            options: self.options
+        }
+    }
+
+    pub fn disable_unknown_attr_warning(self) -> BgpkitParser {
+        let mut options = self.options;
+        options.disable_warning = true;
+        BgpkitParser{
+            reader: self.reader,
+            core_dump: self.core_dump,
+            filters: self.filters,
+            options
         }
     }
 
@@ -56,7 +81,8 @@ impl BgpkitParser {
             BgpkitParser {
                 reader: self.reader,
                 core_dump: self.core_dump,
-                filters
+                filters,
+                options: ParserOptions::default()
             }
         )
     }


### PR DESCRIPTION
Added new internal struct `ParserOptions` to allow further configuration of parser behavior.

The first added new behavior is to configure the parser to disable sending warnings for non-critical parsing issues. You can call `disable_warnings` on a parser struct to configure that.