### PR TITLE
update bgp-models to 0.8.0 for revised serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = "0.1"
 chrono = "0.4"
 regex = "1"
 
-bgp-models = "0.7.0"
+bgp-models = "0.8.0"
 # bgp-models = {git="https://github.com/bgpkit/bgp-models.git", branch="main"}
 
 # logging

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -91,6 +91,7 @@ pub fn parse_bgp_notification_message(input: &mut DataBytes, bgp_msg_length: u64
         BgpNotificationMessage{
             error_code,
             error_subcode,
+            error_type: None,
             data
         })
 }
@@ -137,7 +138,8 @@ pub fn parse_bgp_open_message(input: &mut DataBytes) -> Result<BgpOpenMessage, P
                     Capability{
                         code,
                         len,
-                        value
+                        value,
+                        capability_type: None
                     }
                 )
             }


### PR DESCRIPTION
This updates the json serialization format for messages. More specifically:
1. `elem-type` --> `type`
2. all ASNs are now shown as u32 numbers, instead of a struct

This pull request fixes #66.