### PR TITLE
remove handing afi outside attributes

### DIFF
--- a/src/parser/bgp/attributes.rs
+++ b/src/parser/bgp/attributes.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use bgp_models::bgp::attributes::*;
 use bgp_models::bgp::community::*;
 use bgp_models::network::*;
-use log::{warn,debug};
+use log::warn;
 
 
 use num_traits::FromPrimitive;
@@ -433,7 +433,6 @@ impl AttributeParser {
                         buffer[i] = b;
                     }
                     let ec = ExtendedCommunity::Raw(buffer);
-                    debug!("unsupported community type, parse as raw bytes: {}", &ec);
                     communities.push(ec);
                     continue
                 }

--- a/src/parser/bmp/messages/route_mirroring.rs
+++ b/src/parser/bmp/messages/route_mirroring.rs
@@ -1,5 +1,5 @@
 use bgp_models::bgp::BgpUpdateMessage;
-use bgp_models::network::{Afi, AsnLength};
+use bgp_models::network::AsnLength;
 use crate::parser::bgp::messages::parse_bgp_update_message;
 use crate::parser::bmp::error::ParserBmpError;
 use crate::num_traits::FromPrimitive;
@@ -28,7 +28,7 @@ pub enum RouteMirroringInfo {
     MessageLost=1,
 }
 
-pub fn parse_route_mirroring(reader: &mut DataBytes, afi: &Afi, asn_len: &AsnLength) -> Result<RouteMirroring, ParserBmpError> {
+pub fn parse_route_mirroring(reader: &mut DataBytes, asn_len: &AsnLength) -> Result<RouteMirroring, ParserBmpError> {
     let mut tlvs = vec![];
     while reader.bytes_left() > 4 {
         match reader.read_16b()? {
@@ -36,7 +36,7 @@ pub fn parse_route_mirroring(reader: &mut DataBytes, afi: &Afi, asn_len: &AsnLen
                 let info_len = reader.read_16b()?;
                 let bytes = reader.read_n_bytes(info_len as usize)?;
                 let mut data = DataBytes::new(&bytes);
-                let value = parse_bgp_update_message(&mut data, false, afi, asn_len, info_len as u64)?;
+                let value = parse_bgp_update_message(&mut data, false, asn_len, info_len as u64)?;
                 tlvs.push(RouteMirroringTlv{ info_len, value: RouteMirroringValue::BgpMessage(value)});
             }
             1 => {

--- a/src/parser/bmp/messages/route_monitoring.rs
+++ b/src/parser/bmp/messages/route_monitoring.rs
@@ -1,5 +1,5 @@
 use bgp_models::bgp::BgpMessage;
-use bgp_models::network::{Afi, AsnLength};
+use bgp_models::network::AsnLength;
 use crate::parser::bgp::messages::parse_bgp_message;
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::DataBytes;
@@ -9,9 +9,9 @@ pub struct RouteMonitoring {
     pub bgp_message: BgpMessage
 }
 
-pub fn parse_route_monitoring(reader: &mut DataBytes, afi: &Afi, asn_len: &AsnLength) -> Result<RouteMonitoring, ParserBmpError> {
+pub fn parse_route_monitoring(reader: &mut DataBytes, asn_len: &AsnLength) -> Result<RouteMonitoring, ParserBmpError> {
     // let bgp_update = parse_bgp_update_message(reader, false, afi, asn_len, total_len)?;
-    let bgp_update = parse_bgp_message(reader, false, afi, asn_len, reader.bytes_left())?;
+    let bgp_update = parse_bgp_message(reader, false, asn_len, reader.bytes_left())?;
     Ok(RouteMonitoring{
         bgp_message: bgp_update
     })

--- a/src/parser/bmp/mod.rs
+++ b/src/parser/bmp/mod.rs
@@ -40,7 +40,7 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
         BmpMsgType::RouteMonitoring => {
             let per_peer_header = parse_per_peer_header(&mut data_bytes)?;
             let msg = parse_route_monitoring(&mut data_bytes,
-                                             &per_peer_header.afi, &per_peer_header.asn_len)?;
+                                             &per_peer_header.asn_len)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -51,8 +51,7 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
         }
         BmpMsgType::RouteMirroringMessage => {
             let per_peer_header = parse_per_peer_header(&mut data_bytes)?;
-            let msg = parse_route_mirroring(&mut data_bytes,
-                                            &per_peer_header.afi, &per_peer_header.asn_len)?;
+            let msg = parse_route_mirroring(&mut data_bytes, &per_peer_header.asn_len)?;
             Ok(
                 BmpMessage{
                     common_header,

--- a/src/parser/mrt/messages/bgp4mp.rs
+++ b/src/parser/mrt/messages/bgp4mp.rs
@@ -71,7 +71,7 @@ pub fn parse_bgp4mp_message(input: &mut DataBytes, add_path: bool, asn_len: AsnL
     let local_ip = input.read_address(&afi)?;
 
     let should_read = total_should_read(&afi, &asn_len, total_size);
-    let bgp_message: BgpMessage = parse_bgp_message(input,add_path, &afi, &asn_len, should_read)?;
+    let bgp_message: BgpMessage = parse_bgp_message(input,add_path, &asn_len, should_read)?;
 
     Ok(Bgp4MpMessage{
         msg_type: msg_type.clone(),

--- a/src/parser/rislive/messages/raw_bytes.rs
+++ b/src/parser/rislive/messages/raw_bytes.rs
@@ -39,10 +39,10 @@ pub fn parse_raw_bytes(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisliveError
 
     let peer_asn = peer_asn_str.parse::<i32>().unwrap().into();
 
-    let bgp_msg = match parse_bgp_message(&mut data_bytes, false, &afi, &AsnLength::Bits32, 40960) {
+    let bgp_msg = match parse_bgp_message(&mut data_bytes, false, &AsnLength::Bits32, 40960) {
         Ok(m) => {m}
         Err(_) => {
-            match parse_bgp_message(&mut data_bytes, false, &afi, &AsnLength::Bits16, 40960) {
+            match parse_bgp_message(&mut data_bytes, false, &AsnLength::Bits16, 40960) {
                 Ok(m) => {m}
                 Err(_) => {return Err(ParserRisliveError::IncorrectRawBytes)}
             }


### PR DESCRIPTION
specifically, for `parse_bgp_update_message` function, the withdrawn prefixes and NLRI parsing
outside the attributes are IPv4 only, and we remove passing the AFI parsed from previous stage
to there for NRLI parsing.

This addresses the issue where IPv4 prefixes where wrongfully treated as IPv6 prefixes.

This fixes #72 