### PR TITLE
Remove custom `DataBytes` struct

### DIFF
--- a/bgp-models/src/bgp/attributes.rs
+++ b/bgp-models/src/bgp/attributes.rs
@@ -158,6 +158,12 @@ pub struct AsPath {
     pub segments: Vec<AsPathSegment>,
 }
 
+impl Default for AsPath {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AsPath {
     pub fn new() -> AsPath {
         AsPath { segments: vec![] }
@@ -231,11 +237,7 @@ impl AsPath {
         if let Some(seg) = self.segments.last() {
             match seg {
                 AsPathSegment::AsSequence(v) => {
-                    if let Some(n) = v.last() {
-                        Some(vec![n.clone()])
-                    } else {
-                        None
-                    }
+                    v.last().map(|n| vec![*n])
                 }
                 AsPathSegment::AsSet(v) => { Some(v.clone()) }
                 AsPathSegment::ConfedSequence(_) | AsPathSegment::ConfedSet(_) => { None }

--- a/bgp-models/src/bgp/capabilities.rs
+++ b/bgp-models/src/bgp/capabilities.rs
@@ -58,7 +58,7 @@ pub enum BgpCapabilityType {
 pub fn parse_capability(capability_code: &u8) -> Result<BgpCapabilityType, BgpCapabilityParsingError> {
     match BgpCapabilityType::from_u8(*capability_code) {
         Some(v) => {
-            return Ok(v)
+            Ok(v)
         }
         None => {
             if [4, 66, 128, 129, 130, 131, 184, 185].contains(capability_code) {

--- a/bgp-models/src/bgp/elem.rs
+++ b/bgp-models/src/bgp/elem.rs
@@ -20,10 +20,10 @@ pub enum ElemType {
 
 impl Serialize for ElemType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        Ok(serializer.serialize_str(match self {
+        serializer.serialize_str(match self {
             ElemType::ANNOUNCE => {"announce"}
             ElemType::WITHDRAW => {"withdraw"}
-        })?)
+        })
     }
 }
 

--- a/bgp-models/src/bgp/role.rs
+++ b/bgp-models/src/bgp/role.rs
@@ -37,31 +37,31 @@ pub fn validate_role_pairs(local_role: &BgpRole, remote_role: &BgpRole) -> bool 
             if let BgpRole::Customer =  remote_role {
                 return true
             }
-            return false
+            false
         }
         BgpRole::RouteServer => {
             if let BgpRole::RouteServerClient =  remote_role {
                 return true
             }
-            return false
+            false
         }
         BgpRole::RouteServerClient => {
             if let BgpRole::RouteServer =  remote_role {
                 return true
             }
-            return false
+            false
         }
         BgpRole::Customer => {
             if let BgpRole::Provider =  remote_role {
                 return true
             }
-            return false
+            false
         }
         BgpRole::Peer => {
             if let BgpRole::Peer =  remote_role {
                 return true
             }
-            return false
+            false
         }
     }
 }

--- a/bgp-models/src/network.rs
+++ b/bgp-models/src/network.rs
@@ -65,21 +65,21 @@ impl From<i32> for Asn {
     }
 }
 
-impl Into<i32> for Asn {
-    fn into(self) -> i32 {
-        self.asn as i32
+impl From<Asn> for i32 {
+    fn from(val: Asn) -> Self {
+        val.asn as i32
     }
 }
 
-impl Into<u32> for Asn {
-    fn into(self) -> u32 {
-        self.asn
+impl From<Asn> for u32 {
+    fn from(value: Asn) -> Self {
+        value.asn
     }
 }
 
 impl Serialize for Asn {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        Ok( serializer.serialize_u32(self.asn)?)
+        serializer.serialize_u32(self.asn)
     }
 }
 

--- a/bgpkit-parser-py/src/lib.rs
+++ b/bgpkit-parser-py/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Read;
 use bgpkit_parser::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -61,7 +62,7 @@ fn pybgpkit_parser(_py: Python, m: &PyModule) -> PyResult<()> {
     #[pyclass]
     #[pyo3(text_signature = "(url, filters, /)")]
     struct Parser {
-        elem_iter: ElemIterator,
+        elem_iter: ElemIterator<Box<dyn Send + Read>>,
     }
 
     #[pymethods]

--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.69"
 # bmp/openbmp parsing
 hex="0.4.3"
 
-oneio = {version= "0.7.0", features=["lib_only"]}
+oneio = {version= "0.7.2", features=["lib_only"]}
 
 env_logger = {version="0.10", optional=true}
 clap = {version= "4.0", features=["derive"], optional=true}

--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -21,6 +21,7 @@ enum-primitive-derive = "0.2"
 num-traits = "0.2"
 chrono = "0.4"
 regex = "1"
+byteorder = "1"
 
 bgp-models = {path="../bgp-models", version="0.9.0-alpha-1"}
 
@@ -43,7 +44,6 @@ clap = {version= "4.0", features=["derive"], optional=true}
 [dev-dependencies]
 bgpkit-broker = "0.3.2"
 kafka = "0.9.0"
-# websocket
 tungstenite= "0.18.0"
 url = "2.1.0"
 criterion = {version= "0.4.0", features=["html_reports"]}

--- a/bgpkit-parser/examples/real-time-routeviews-kafka-openbmp.rs
+++ b/bgpkit-parser/examples/real-time-routeviews-kafka-openbmp.rs
@@ -1,3 +1,6 @@
+extern crate core;
+
+use std::io::Cursor;
 use std::thread::sleep;
 use std::time::Duration;
 use kafka::consumer::{Consumer, FetchOffset, GroupOffsetStorage};
@@ -6,7 +9,6 @@ pub use bgpkit_parser::{parse_bmp_msg, parse_openbmp_header};
 use log::{info, error};
 use bgpkit_parser::Elementor;
 use bgpkit_parser::parser::bmp::messages::MessageBody;
-use bgpkit_parser::parser::utils::DataBytes;
 
 fn consume_and_print(group: String, topic: String, brokers: Vec<String>) -> Result<(), KafkaError>{
 
@@ -30,7 +32,7 @@ fn consume_and_print(group: String, topic: String, brokers: Vec<String>) -> Resu
         for ms in mss.iter() {
             for m in ms.messages() {
                 let bytes = m.value.to_vec();
-                let mut reader = DataBytes::new(&bytes);
+                let mut reader = Cursor::new(bytes.as_slice());
                 let header = parse_openbmp_header(&mut reader).unwrap();
                 let bmp_msg = parse_bmp_msg(&mut reader);
                 match bmp_msg {

--- a/bgpkit-parser/src/error.rs
+++ b/bgpkit-parser/src/error.rs
@@ -1,4 +1,4 @@
-use std::{convert, error::Error, fmt, io};
+use std::{error::Error, fmt, io};
 use std::fmt::{Display, Formatter};
 use std::io::ErrorKind;
 use oneio::OneIoError;
@@ -8,7 +8,7 @@ pub enum ParserError {
     IoError(io::Error),
     IoNotEnoughBytes(),
     EofError(io::Error),
-    OneIoError(oneio::OneIoError),
+    OneIoError(OneIoError),
     EofExpected,
     ParseError(String),
     UnknownAttr(String),
@@ -73,7 +73,7 @@ impl From<ParserError> for ParserErrorWithBytes {
     }
 }
 
-impl convert::From<io::Error> for ParserError {
+impl From<io::Error> for ParserError {
     fn from(io_error: io::Error) -> Self {
         match io_error.kind() {
             ErrorKind::UnexpectedEof => { ParserError::EofError(io_error)}

--- a/bgpkit-parser/src/lib.rs
+++ b/bgpkit-parser/src/lib.rs
@@ -313,6 +313,9 @@ We support normal communities, extended communities, and large communities.
 [mrt-record-doc]: https://docs.rs/bgp-models/0.3.4/bgp_models/mrt/struct.MrtRecord.html
 */
 
+#![allow(clippy::new_without_default)]
+#![allow(clippy::needless_range_loop)]
+
 #[macro_use]
 extern crate enum_primitive_derive;
 extern crate core;

--- a/bgpkit-parser/src/lib.rs
+++ b/bgpkit-parser/src/lib.rs
@@ -315,6 +315,7 @@ We support normal communities, extended communities, and large communities.
 
 #[macro_use]
 extern crate enum_primitive_derive;
+extern crate core;
 
 pub mod error;
 pub mod parser;
@@ -328,6 +329,5 @@ pub use parser::bmp::parse_bmp_msg;
 pub use parser::bmp::parse_openbmp_header;
 pub use parser::rislive::parse_ris_live_message;
 pub use parser::mrt::parse_mrt_record;
-pub use parser::utils::ReadUtils;
 pub use parser::filter::*;
 pub use bgp_models::prelude::*;

--- a/bgpkit-parser/src/parser/bgp/attributes.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes.rs
@@ -1,15 +1,16 @@
 use std::net::{Ipv4Addr};
-use std::convert::TryFrom;
+use std::io::{Cursor, Seek, SeekFrom};
+use byteorder::{BE, ReadBytesExt};
 use bgp_models::bgp::attributes::*;
 use bgp_models::bgp::community::*;
 use bgp_models::network::*;
-use log::warn;
+use log::{debug, warn};
 
 
 use num_traits::FromPrimitive;
 
 use crate::error::ParserError;
-use crate::parser::DataBytes;
+use crate::parser::{parse_nlri_list, ReadUtils};
 
 
 pub struct AttributeParser {
@@ -29,25 +30,32 @@ impl AttributeParser {
         }
     }
 
+    /// Parse BGP attributes given a slice of u8 and some options.
+    ///
+    /// The `data: &[u8]` contains the entirety of the attributes bytes, therefore the size of
+    /// the slice is the total byte length of the attributes section of the message.
     pub fn parse_attributes(
         &self,
-        input: &mut DataBytes,
+        data: &[u8],
         asn_len: &AsnLength,
         afi: Option<Afi>,
         safi: Option<Safi>,
         prefixes: Option<&[NetworkPrefix]>,
-        total_bytes: usize,
     ) -> Result<Vec<Attribute>, ParserError> {
         let mut attributes: Vec<Attribute> = Vec::with_capacity(20);
-        let attrs_end_pos = input.pos + total_bytes;
+        let total_slices_bytes = data.len() as u64;
+        let mut input = Cursor::new(data);
 
-        while input.pos < attrs_end_pos - 3 {
+        while input.position() + 3 <= total_slices_bytes  {
+            // each attribute is at least 3 bytes: flag(1) + type(1) + length(1)
+            // thus the while loop condition is set to be at least 3 bytes to read.
+
             // has content to read
-            let flag = input.read_8b()?;
-            let attr_type = input.read_8b()?;
+            let flag = input.read_u8()?;
+            let attr_type = input.read_u8()?;
             let length = match flag & AttributeFlagsBit::ExtendedLengthBit as u8 {
-                0 => input.read_8b()? as usize,
-                _ => input.read_16b()? as usize,
+                0 => input.read_u8()? as usize,
+                _ => input.read_u16::<BE>()? as usize,
             };
 
             let mut partial = false;
@@ -67,63 +75,68 @@ impl AttributeParser {
                 partial = true;
             }
 
+            debug!("reading attribute: type -- {:?}, length -- {}", &attr_type, length);
             let attr_type = match AttrType::from_u8(attr_type) {
                 Some(t) => t,
                 None => {
-                    input.read_and_drop_n_bytes(length)?;
+                    // input.read_and_drop_n_bytes(length)?;
+                    input.seek(SeekFrom::Current(length as i64))?;
                     return match attr_type {
                         11 | 12 | 13 | 19 | 20 | 21 | 28 | 30 | 31 | 129 | 241..=243 => {
-                            Err(crate::error::ParserError::DeprecatedAttr(format!("deprecated attribute type: {}", attr_type)))
+                            Err(ParserError::DeprecatedAttr(format!("deprecated attribute type: {}", attr_type)))
                         }
                         _ => {
-                            Err(crate::error::ParserError::UnknownAttr(format!("unknown attribute type: {}", attr_type)))
+                            Err(ParserError::UnknownAttr(format!("unknown attribute type: {}", attr_type)))
                         }
                     }
                 }
             };
 
-            if input.bytes_left()< length {
-                warn!("not enough bytes: input bytes left - {}, want to read - {}; skipping", input.bytes_left(), length);
+            let bytes_left = total_slices_bytes - input.position();
+            let attr_end_pos = input.position() + length as u64;
+
+            if bytes_left < length as u64 {
+                warn!("not enough bytes: input bytes left - {}, want to read - {}; skipping", bytes_left, length);
                 break
             }
 
-            let attr_end_pos = input.pos+length;
-
             let attr = match attr_type {
-                AttrType::ORIGIN => self.parse_origin(input),
-                AttrType::AS_PATH => self.parse_as_path(input, asn_len, length),
-                AttrType::NEXT_HOP => self.parse_next_hop(input, &afi),
-                AttrType::MULTI_EXIT_DISCRIMINATOR => self.parse_med(input),
-                AttrType::LOCAL_PREFERENCE => self.parse_local_pref(input),
+                AttrType::ORIGIN => self.parse_origin(&mut input),
+                AttrType::AS_PATH => self.parse_as_path(&mut input, asn_len, length),
+                AttrType::NEXT_HOP => self.parse_next_hop(&mut input, &afi),
+                AttrType::MULTI_EXIT_DISCRIMINATOR => self.parse_med(&mut input),
+                AttrType::LOCAL_PREFERENCE => self.parse_local_pref(&mut input),
                 AttrType::ATOMIC_AGGREGATE => Ok(AttributeValue::AtomicAggregate(AtomicAggregate::AG)),
-                AttrType::AGGREGATOR => self.parse_aggregator(input, asn_len, &afi),
-                AttrType::ORIGINATOR_ID => self.parse_originator_id(input, &afi),
-                AttrType::CLUSTER_LIST => self.parse_clusters(input, &afi, length),
+                AttrType::AGGREGATOR => self.parse_aggregator(&mut input, asn_len, &afi),
+                AttrType::ORIGINATOR_ID => self.parse_originator_id(&mut input, &afi),
+                AttrType::CLUSTER_LIST => self.parse_clusters(&mut input, &afi, length),
                 AttrType::MP_REACHABLE_NLRI => {
-                        self.parse_nlri(input, &afi, &safi, &prefixes, true, length)
+                        self.parse_nlri(&mut input, &afi, &safi, &prefixes, true, length)
                 }
-                AttrType::MP_UNREACHABLE_NLRI => self.parse_nlri(input, &afi, &safi, &prefixes, false, length),
-                AttrType::AS4_PATH => self.parse_as_path(input, &AsnLength::Bits32, length),
-                AttrType::AS4_AGGREGATOR => self.parse_aggregator(input, &AsnLength::Bits32, &afi),
+                AttrType::MP_UNREACHABLE_NLRI => self.parse_nlri(&mut input, &afi, &safi, &prefixes, false, length),
+                AttrType::AS4_PATH => self.parse_as_path(&mut input, &AsnLength::Bits32, length),
+                AttrType::AS4_AGGREGATOR => self.parse_aggregator(&mut input, &AsnLength::Bits32, &afi),
 
                 // communities
-                AttrType::COMMUNITIES => self.parse_regular_communities(input, length),
-                AttrType::LARGE_COMMUNITIES => self.parse_large_communities(input, length),
-                AttrType::EXTENDED_COMMUNITIES => self.parse_extended_community(input, length) ,
-                AttrType::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITIES => self.parse_ipv6_extended_community(input, length),
+                AttrType::COMMUNITIES => self.parse_regular_communities(&mut input, length),
+                AttrType::LARGE_COMMUNITIES => self.parse_large_communities(&mut input, length),
+                AttrType::EXTENDED_COMMUNITIES => self.parse_extended_community(&mut input, length) ,
+                AttrType::IPV6_ADDRESS_SPECIFIC_EXTENDED_COMMUNITIES => self.parse_ipv6_extended_community(&mut input, length),
                 AttrType::DEVELOPMENT => {
-                    let buf = input.read_n_bytes(length)?;
-                    Ok(AttributeValue::Development(buf))
+                    let mut value = vec![];
+                    for _i in 0..length {
+                        value.push(input.read_u8()?);
+                    }
+                    Ok(AttributeValue::Development(value))
                 },
                 _ => {
                     Err(crate::error::ParserError::Unsupported(format!("unsupported attribute type: {:?}", attr_type)))
                 }
             };
 
+            debug!("seeking position tp {}/{}", attr_end_pos, input.get_ref().len());
             // always fast forward to the attribute end position.
-            if input.pos!= attr_end_pos {
-                input.fast_forward(attr_end_pos);
-            }
+            input.seek(SeekFrom::Start(attr_end_pos))?;
 
             match attr{
                 Ok(value) => {
@@ -141,15 +154,11 @@ impl AttributeParser {
             };
         }
 
-        if input.pos!= attrs_end_pos {
-            input.fast_forward(attrs_end_pos);
-        }
-
         Ok(attributes)
     }
 
-    fn parse_origin(&self, input: &mut DataBytes) -> Result<AttributeValue, ParserError> {
-        let origin = input.read_8b()?;
+    fn parse_origin(&self, input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
+        let origin = input.read_u8()?;
         match Origin::from_u8(origin) {
             Some(v) => Ok(AttributeValue::Origin(v)),
             None => {
@@ -158,19 +167,19 @@ impl AttributeParser {
         }
     }
 
-    fn parse_as_path(&self, input: &mut DataBytes, asn_len: &AsnLength, total_bytes: usize) -> Result<AttributeValue, ParserError> {
+    fn parse_as_path(&self, input: &mut Cursor<&[u8]>, asn_len: &AsnLength, total_bytes: usize) -> Result<AttributeValue, ParserError> {
         let mut output = AsPath{ segments: Vec::with_capacity(5) };
-        let pos_end = input.pos + total_bytes;
-        while input.pos < pos_end {
+        let pos_end = input.position() + total_bytes as u64;
+        while input.position() < pos_end {
             let segment = self.parse_as_segment(input, asn_len)?;
             output.add_segment(segment);
         }
         Ok(AttributeValue::AsPath(output))
     }
 
-    fn parse_as_segment(&self, input: &mut DataBytes, asn_len: &AsnLength) -> Result<AsPathSegment, ParserError> {
-        let segment_type = input.read_8b()?;
-        let count = input.read_8b()?;
+    fn parse_as_segment(&self, input: &mut Cursor<&[u8]>, asn_len: &AsnLength) -> Result<AsPathSegment, ParserError> {
+        let segment_type = input.read_u8()?;
+        let count = input.read_u8()?;
         let path = input.read_asns(asn_len, count as usize)?;
         match segment_type {
             AttributeParser::AS_PATH_AS_SET => Ok(AsPathSegment::AsSet(path)),
@@ -183,7 +192,7 @@ impl AttributeParser {
         }
     }
 
-    fn parse_next_hop(&self, input: &mut DataBytes, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
+    fn parse_next_hop(&self, input: &mut Cursor<&[u8]>, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
         if let Some(afi) = afi {
             Ok(input.read_address(afi).map(AttributeValue::NextHop)?)
         } else {
@@ -191,19 +200,21 @@ impl AttributeParser {
         }
     }
 
-    fn parse_med(&self, input: &mut DataBytes) -> Result<AttributeValue, ParserError> {
-        input
-            .read_32b()
-            .map(AttributeValue::MultiExitDiscriminator)
+    fn parse_med(&self, input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
+        match input.read_u32::<BE>(){
+            Ok(v) => {Ok(AttributeValue::MultiExitDiscriminator(v))}
+            Err(err) => {Err(ParserError::from(err))}
+        }
     }
 
-    fn parse_local_pref(&self, input: &mut DataBytes) -> Result<AttributeValue, ParserError> {
-        input
-            .read_32b()
-            .map(AttributeValue::LocalPreference)
+    fn parse_local_pref(&self, input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
+        match input.read_u32::<BE>(){
+            Ok(v) => {Ok(AttributeValue::LocalPreference(v))}
+            Err(err) => {Err(ParserError::from(err))}
+        }
     }
 
-    fn parse_aggregator(&self, input: &mut DataBytes, asn_len: &AsnLength, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
+    fn parse_aggregator(&self, input: &mut Cursor<&[u8]>, asn_len: &AsnLength, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
         let asn = input.read_asn(asn_len)?;
         let afi = match afi {
             None => { &Afi::Ipv4 }
@@ -213,23 +224,25 @@ impl AttributeParser {
         Ok(AttributeValue::Aggregator(asn, addr))
     }
 
-    fn parse_regular_communities(&self, input: &mut DataBytes, total_bytes: usize) -> Result<AttributeValue, ParserError> {
+    fn parse_regular_communities(&self, input: &mut Cursor<&[u8]>, total_bytes: usize) -> Result<AttributeValue, ParserError> {
         const COMMUNITY_NO_EXPORT: u32 = 0xFFFFFF01;
         const COMMUNITY_NO_ADVERTISE: u32 = 0xFFFFFF02;
         const COMMUNITY_NO_EXPORT_SUBCONFED: u32 = 0xFFFFFF03;
-        let mut communities = vec![];
 
+        debug!("reading communities. cursor_pos: {}/{}; total to read: {}", input.position(), input.get_ref().len(), total_bytes);
+
+        let mut communities = vec![];
         let mut read = 0;
 
         while read < total_bytes {
-            let community_val = input.read_32b()?;
+            let community_val = input.read_u32::<BE>()?;
             communities.push(
                 match community_val {
                     COMMUNITY_NO_EXPORT => Community::NoExport,
                     COMMUNITY_NO_ADVERTISE => Community::NoAdvertise,
                     COMMUNITY_NO_EXPORT_SUBCONFED => Community::NoExportSubConfed,
                     value => {
-                        let asn = Asn{asn: ((value >> 16) & 0xffff) as u32, len: AsnLength::Bits16};
+                        let asn = Asn{asn: ((value >> 16) & 0xffff), len: AsnLength::Bits16};
                         let value = (value & 0xffff) as u16;
                         Community::Custom(asn, value)
                     }
@@ -237,10 +250,12 @@ impl AttributeParser {
             );
             read += 4;
         }
+
+        debug!("finished reading communities. cursor_pos: {}/{}; {:?}", input.position(), input.get_ref().len(), &communities);
         Ok(AttributeValue::Communities(communities))
     }
 
-    fn parse_originator_id(&self, input: &mut DataBytes, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
+    fn parse_originator_id(&self, input: &mut Cursor<&[u8]>, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
         let afi = match afi {
             None => { &Afi::Ipv4 }
             Some(a) => {a}
@@ -250,7 +265,7 @@ impl AttributeParser {
     }
 
     #[allow(unused)]
-    fn parse_cluster_id(&self, input: &mut DataBytes, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
+    fn parse_cluster_id(&self, input: &mut Cursor<&[u8]>, afi: &Option<Afi>) -> Result<AttributeValue, ParserError> {
         let afi = match afi {
             None => { &Afi::Ipv4 }
             Some(a) => {a}
@@ -259,19 +274,17 @@ impl AttributeParser {
         Ok(AttributeValue::Clusters(vec![addr]))
     }
 
-    fn parse_clusters(&self, input: &mut DataBytes, afi: &Option<Afi>, total_bytes: usize) -> Result<AttributeValue, ParserError> {
+    fn parse_clusters(&self, input: &mut Cursor<&[u8]>, afi: &Option<Afi>, total_bytes: usize) -> Result<AttributeValue, ParserError> {
         // FIXME: in https://tools.ietf.org/html/rfc4456, the CLUSTER_LIST is a set of CLUSTER_ID each represented by a 4-byte number
         let mut clusters = Vec::new();
-        let mut read = 0;
-        while read < total_bytes {
+        let initial_pos = input.position();
+        while input.position() - initial_pos < total_bytes as u64 {
             let afi = match afi {
                 None => { &Afi::Ipv4 }
                 Some(a) => {a}
             };
 
-            let pos = input.pos;
             let addr = input.read_address(afi)?;
-            read+= input.pos - pos;
 
             clusters.push(addr);
         }
@@ -294,14 +307,14 @@ impl AttributeParser {
     /// +---------------------------------------------------------+
     /// | Network Layer Reachability Information (variable)       |
     /// +---------------------------------------------------------+
-    fn parse_nlri(&self, input: &mut DataBytes,
+    fn parse_nlri(&self, input: &mut Cursor<&[u8]>,
                                    afi: &Option<Afi>, safi: &Option<Safi>,
                                    prefixes: &Option<&[NetworkPrefix]>,
                                    reachable: bool,
         total_bytes: usize,
     ) -> Result<AttributeValue, ParserError> {
-        let first_byte_zero = input.bytes[input.pos]==0;
-        let pos_end = input.pos + total_bytes;
+        let first_byte_zero = input.get_ref()[input.position() as usize]==0;
+        let pos_end = input.position() + total_bytes as u64;
 
         // read address family
         let afi = match afi {
@@ -327,7 +340,7 @@ impl AttributeParser {
 
         let mut next_hop = None;
         if reachable {
-            let next_hop_length = input.read_8b()?;
+            let next_hop_length = input.read_u8()?;
             next_hop = match self.parse_mp_next_hop(next_hop_length, input) {
                 Ok(x) => x,
                 Err(e) => {
@@ -336,7 +349,7 @@ impl AttributeParser {
             };
         }
 
-        let mut bytes_left = pos_end - input.pos;
+        let mut bytes_left = pos_end - input.position();
 
         let prefixes = match prefixes {
             Some(pfxs) => {
@@ -344,12 +357,12 @@ impl AttributeParser {
                 if first_byte_zero {
                     if reachable {
                         // skip reserved byte for reachable NRLI
-                        if input.read_8b()? !=0 {
+                        if input.read_u8()? !=0 {
                             warn!("NRLI reserved byte not 0");
                         }
                         bytes_left-=1;
                     }
-                    input.parse_nlri_list( self.additional_paths, &afi, bytes_left)?
+                    parse_nlri_list( input, self.additional_paths, &afi, bytes_left)?
                 } else {
                     pfxs.to_vec()
                 }
@@ -357,12 +370,12 @@ impl AttributeParser {
             None => {
                 if reachable {
                     // skip reserved byte for reachable NRLI
-                    if input.read_8b()? !=0 {
+                    if input.read_u8()? !=0 {
                         warn!("NRLI reserved byte not 0");
                     }
                     bytes_left-=1;
                 }
-                input.parse_nlri_list(self.additional_paths, &afi, bytes_left)?
+                parse_nlri_list(input, self.additional_paths, &afi, bytes_left)?
             }
         };
 
@@ -376,7 +389,7 @@ impl AttributeParser {
     fn parse_mp_next_hop(
         &self,
         next_hop_length: u8,
-        input: &mut DataBytes,
+        input: &mut Cursor<&[u8]>,
     ) -> Result<Option<NextHopAddress>, ParserError> {
         let output = match next_hop_length {
             0 => None,
@@ -397,16 +410,16 @@ impl AttributeParser {
 
     fn parse_large_communities(
         &self,
-        input: &mut DataBytes,
+        input: &mut Cursor<&[u8]>,
         total_bytes: usize,
     ) -> Result<AttributeValue, ParserError> {
         let mut communities = Vec::new();
-        let pos_end = input.pos + total_bytes;
-        while input.pos < pos_end {
-            let global_administrator = input.read_32b()?;
+        let pos_end = input.position() + total_bytes as u64;
+        while input.position() < pos_end {
+            let global_administrator = input.read_u32::<BE>()?;
             let local_data = [
-                input.read_32b()?,
-                input.read_32b()?,
+                input.read_u32::<BE>()?,
+                input.read_u32::<BE>()?,
             ];
             communities.push(LargeCommunity::new(global_administrator, local_data));
         }
@@ -415,22 +428,22 @@ impl AttributeParser {
 
     fn parse_extended_community(
         &self,
-        input: &mut DataBytes,
+        input: &mut Cursor<&[u8]>,
         total_bytes: usize,
     ) -> Result<AttributeValue, ParserError> {
         let mut communities = Vec::new();
-        let pos_end = input.pos + total_bytes;
-        while input.pos < pos_end {
-            let ec_type_u8 = input.read_8b()?;
+        let pos_end = input.position() + total_bytes as u64;
+        while input.position() < pos_end {
+            let ec_type_u8 = input.read_u8()?;
             let ec_type: ExtendedCommunityType = match ExtendedCommunityType::from_u8(ec_type_u8){
                 Some(t) => t,
                 None => {
                     let mut buffer: [u8;8] = [0;8];
                     let mut i = 0;
                     buffer[i] = ec_type_u8;
-                    for b in input.read_n_bytes(7)? {
+                    for _b in 0..7 {
                         i += 1;
-                        buffer[i] = b;
+                        buffer[i] = input.read_u8()?;
                     }
                     let ec = ExtendedCommunity::Raw(buffer);
                     communities.push(ec);
@@ -439,88 +452,108 @@ impl AttributeParser {
             };
             let ec: ExtendedCommunity = match ec_type {
                 ExtendedCommunityType::TransitiveTwoOctetAsSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = input.read_16b()?;
-                    let local = input.read_n_bytes(4)?;
+                    let sub_type = input.read_u8()?;
+                    let global = input.read_u16::<BE>()?;
+                    let mut local: [u8;4] = [0;4];
+                    for i in 0..4 {
+                        local[i] = input.read_u8()?;
+                    }
                     ExtendedCommunity::TransitiveTwoOctetAsSpecific( TwoOctetAsSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: Asn{asn:global as u32, len: AsnLength::Bits16},
-                        local_administrator: <[u8; 4]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
                 ExtendedCommunityType::NonTransitiveTwoOctetAsSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = input.read_16b()?;
-                    let local = input.read_n_bytes(4)?;
+                    let sub_type = input.read_u8()?;
+                    let global = input.read_u16::<BE>()?;
+                    let mut local: [u8;4] = [0;4];
+                    for i in 0..4 {
+                        local[i] = input.read_u8()?;
+                    }
                     ExtendedCommunity::NonTransitiveTwoOctetAsSpecific( TwoOctetAsSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: Asn{asn:global as u32, len: AsnLength::Bits16},
-                        local_administrator: <[u8; 4]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
 
                 ExtendedCommunityType::TransitiveIpv4AddressSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = Ipv4Addr::from(input.read_32b()?);
-                    let local = input.read_n_bytes(2)?;
+                    let sub_type = input.read_u8()?;
+                    let global = Ipv4Addr::from(input.read_u32::<BE>()?);
+                    let mut local: [u8;2] = [0;2];
+                    local[0] = input.read_u8()?;
+                    local[1] = input.read_u8()?;
                     ExtendedCommunity::TransitiveIpv4AddressSpecific( Ipv4AddressSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: global,
-                        local_administrator: <[u8; 2]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
                 ExtendedCommunityType::NonTransitiveIpv4AddressSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = Ipv4Addr::from(input.read_32b()?);
-                    let local = input.read_n_bytes(2)?;
+                    let sub_type = input.read_u8()?;
+                    let global = Ipv4Addr::from(input.read_u32::<BE>()?);
+                    let mut local: [u8;2] = [0;2];
+                    local[0] = input.read_u8()?;
+                    local[1] = input.read_u8()?;
                     ExtendedCommunity::NonTransitiveIpv4AddressSpecific( Ipv4AddressSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: global,
-                        local_administrator: <[u8; 2]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
                 ExtendedCommunityType::TransitiveFourOctetAsSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = input.read_32b()?;
-                    let local = input.read_n_bytes(2)?;
+                    let sub_type = input.read_u8()?;
+                    let global = input.read_u32::<BE>()?;
+                    let mut local: [u8;2] = [0;2];
+                    local[0] = input.read_u8()?;
+                    local[1] = input.read_u8()?;
                     ExtendedCommunity::TransitiveFourOctetAsSpecific( FourOctetAsSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: Asn{asn:global as u32, len: AsnLength::Bits32},
-                        local_administrator: <[u8; 2]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
                 ExtendedCommunityType::NonTransitiveFourOctetAsSpecific => {
-                    let sub_type = input.read_8b()?;
-                    let global = input.read_32b()?;
-                    let local = input.read_n_bytes(2)?;
+                    let sub_type = input.read_u8()?;
+                    let global = input.read_u32::<BE>()?;
+                    let mut local: [u8;2] = [0;2];
+                    local[0] = input.read_u8()?;
+                    local[1] = input.read_u8()?;
                     ExtendedCommunity::NonTransitiveFourOctetAsSpecific( FourOctetAsSpecific{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
                         global_administrator: Asn{asn:global as u32, len: AsnLength::Bits32},
-                        local_administrator: <[u8; 2]>::try_from(local).unwrap()
+                        local_administrator: local
                     } )
                 }
                 ExtendedCommunityType::TransitiveOpaque => {
-                    let sub_type = input.read_8b()?;
-                    let value = input.read_n_bytes(6)?;
+                    let sub_type = input.read_u8()?;
+                    let mut value: [u8;6] = [0;6];
+                    for i in 0..6 {
+                        value[i] = input.read_u8()?;
+                    }
                     ExtendedCommunity::TransitiveOpaque( Opaque{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
-                        value: <[u8; 6]>::try_from(value).unwrap()
+                        value
                     } )
                 }
                 ExtendedCommunityType::NonTransitiveOpaque => {
-                    let sub_type = input.read_8b()?;
-                    let value = input.read_n_bytes(6)?;
+                    let sub_type = input.read_u8()?;
+                    let mut value: [u8;6] = [0;6];
+                    for i in 0..6 {
+                        value[i] = input.read_u8()?;
+                    }
                     ExtendedCommunity::NonTransitiveOpaque( Opaque{
                         ec_type: ec_type_u8,
                         ec_subtype: sub_type,
-                        value: <[u8; 6]>::try_from(value).unwrap()
+                        value
                     } )
                 }
             };
@@ -532,22 +565,24 @@ impl AttributeParser {
 
     fn parse_ipv6_extended_community(
         &self,
-        input: &mut DataBytes,
+        input: &mut Cursor<&[u8]>,
         total_bytes: usize
     ) -> Result<AttributeValue, ParserError> {
         let mut communities = Vec::new();
-        let pos_end = input.pos + total_bytes;
-        while input.pos < pos_end {
-            let ec_type_u8 = input.read_8b()?;
-            let sub_type = input.read_8b()?;
+        let pos_end = input.position() + total_bytes as u64;
+        while input.position() < pos_end {
+            let ec_type_u8 = input.read_u8()?;
+            let sub_type = input.read_u8()?;
             let global = input.read_ipv6_address()?;
-            let local = input.read_n_bytes(2)?;
+            let mut local: [u8;2] = [0;2];
+            local[0] = input.read_u8()?;
+            local[1] = input.read_u8()?;
             let ec = ExtendedCommunity::Ipv6AddressSpecific(
                 Ipv6AddressSpecific {
                     ec_type: ec_type_u8,
                     ec_subtype: sub_type,
                     global_administrator: global,
-                    local_administrator: <[u8; 2]>::try_from(local).unwrap()
+                    local_administrator: local
                 }
             );
             communities.push(ec);

--- a/bgpkit-parser/src/parser/bgp/messages.rs
+++ b/bgpkit-parser/src/parser/bgp/messages.rs
@@ -1,9 +1,11 @@
+use std::io::{Cursor, Seek, SeekFrom};
+use byteorder::{BE, ReadBytesExt};
 use bgp_models::bgp::*;
 use bgp_models::network::*;
 use num_traits::FromPrimitive;
 
 use crate::error::ParserError;
-use crate::parser::{AttributeParser, DataBytes};
+use crate::parser::{AttributeParser, parse_nlri_list, ReadUtils};
 use log::warn;
 
 /// BGP message
@@ -24,13 +26,15 @@ use log::warn;
 /// |          Length               |      Type     |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-pub fn parse_bgp_message(input: &mut DataBytes, add_path: bool, asn_len: &AsnLength, total_size: usize) -> Result<BgpMessage, ParserError> {
+pub fn parse_bgp_message(data: &[u8], add_path: bool, asn_len: &AsnLength) -> Result<BgpMessage, ParserError> {
+    let total_size = data.len();
+    let mut input = Cursor::new(data);
     // https://tools.ietf.org/html/rfc4271#section-4
     // 16 (4 x 4 bytes) octets marker
-    input.read_32b()?;
-    input.read_32b()?;
-    input.read_32b()?;
-    input.read_32b()?;
+    input.read_u32::<BE>()?;
+    input.read_u32::<BE>()?;
+    input.read_u32::<BE>()?;
+    input.read_u32::<BE>()?;
     /*
      This 2-octet unsigned integer indicates the total length of the
      message, including the header in octets.  Thus, it allows one
@@ -42,7 +46,7 @@ pub fn parse_bgp_message(input: &mut DataBytes, add_path: bool, asn_len: &AsnLen
      have the smallest value required, given the rest of the
      message.
      */
-    let length = input.read_16b()?;
+    let length = input.read_u16::<BE>()?;
     if !(19..=4096).contains(&length) {
         return Err(ParserError::ParseError(format!("invalid BGP message length {}", length)))
     }
@@ -55,26 +59,25 @@ pub fn parse_bgp_message(input: &mut DataBytes, add_path: bool, asn_len: &AsnLen
             (length - 19) as u64
         };
 
-    let msg_type: BgpMessageType = match BgpMessageType::from_u8(input.read_8b()?){
+    let msg_type: BgpMessageType = match BgpMessageType::from_u8(input.read_u8()?){
         Some(t) => t,
         None => {
             return Err(ParserError::ParseError("Unknown BGP Message Type".to_string()))
         }
     };
 
-    // make sure we don't read over the bound
+    // TODO: make sure we don't read over the bound
     // let mut bgp_msg_input = input.take(bgp_msg_length);
-
     Ok(
         match msg_type{
             BgpMessageType::OPEN => {
-                BgpMessage::Open(parse_bgp_open_message(input)?)
+                BgpMessage::Open(parse_bgp_open_message(&mut input)?)
             }
             BgpMessageType::UPDATE => {
-                BgpMessage::Update(parse_bgp_update_message(input, add_path, asn_len, bgp_msg_length)?)
+                BgpMessage::Update(parse_bgp_update_message(&mut input, add_path, asn_len, bgp_msg_length)?)
             }
             BgpMessageType::NOTIFICATION => {
-                BgpMessage::Notification(parse_bgp_notification_message(input, bgp_msg_length)?)
+                BgpMessage::Notification(parse_bgp_notification_message(&mut input, bgp_msg_length)?)
             }
             BgpMessageType::KEEPALIVE => {
                 BgpMessage::KeepAlive(BgpKeepAliveMessage{})
@@ -83,10 +86,10 @@ pub fn parse_bgp_message(input: &mut DataBytes, add_path: bool, asn_len: &AsnLen
     )
 }
 
-pub fn parse_bgp_notification_message(input: &mut DataBytes, bgp_msg_length: u64) -> Result<BgpNotificationMessage, ParserError> {
-    let error_code = input.read_8b()?;
-    let error_subcode = input.read_8b()?;
-    let data = input.read_n_bytes((bgp_msg_length - 2) as usize)?;
+pub fn parse_bgp_notification_message(input: &mut Cursor<&[u8]>, bgp_msg_length: u64) -> Result<BgpNotificationMessage, ParserError> {
+    let error_code = input.read_u8()?;
+    let error_subcode = input.read_u8()?;
+    let data = input.read_bytes_vec((bgp_msg_length - 2) as usize)?;
     Ok(
         BgpNotificationMessage{
             error_code,
@@ -96,26 +99,26 @@ pub fn parse_bgp_notification_message(input: &mut DataBytes, bgp_msg_length: u64
         })
 }
 
-pub fn parse_bgp_open_message(input: &mut DataBytes) -> Result<BgpOpenMessage, ParserError> {
-    let version = input.read_8b()?;
-    let asn = Asn{asn: input.read_16b()? as u32, len: AsnLength::Bits16};
-    let hold_time = input.read_16b()?;
+pub fn parse_bgp_open_message(input: &mut Cursor<&[u8]>) -> Result<BgpOpenMessage, ParserError> {
+    let version = input.read_u8()?;
+    let asn = Asn{asn: input.read_u16::<BE>()? as u32, len: AsnLength::Bits16};
+    let hold_time = input.read_u16::<BE>()?;
     let sender_ip = input.read_ipv4_address()?;
-    let opt_params_len = input.read_8b()?;
+    let opt_params_len = input.read_u8()?;
 
-    let pos_end = input.pos + opt_params_len as usize;
+    let pos_end = input.position() + opt_params_len as u64;
 
     let mut extended_length = false;
     let mut first= true;
 
     let mut params: Vec<OptParam> = vec![];
-    while input.pos < pos_end {
-        let param_type = input.read_8b()?;
+    while input.position() < pos_end {
+        let param_type = input.read_u8()?;
         if first {
             // first parameter, check if it is extended length message
             if opt_params_len == 255 && param_type == 255 {
                 extended_length = true;
-                // todo: handle extended length
+                // TODO: handle extended length
                 break
             } else {
                 first = false;
@@ -123,16 +126,16 @@ pub fn parse_bgp_open_message(input: &mut DataBytes) -> Result<BgpOpenMessage, P
         }
         // reaching here means all the remain params are regular non-extended-length parameters
 
-        let parm_length = input.read_8b()?;
+        let parm_length = input.read_u8()?;
         // https://tools.ietf.org/html/rfc3392
         // https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-11
 
         let param_value = match param_type{
             2 => {
                 // capacity
-                let code = input.read_8b()?;
-                let len = input.read_8b()?;
-                let value = input.read_n_bytes(len as usize)?;
+                let code = input.read_u8()?;
+                let len = input.read_u8()?;
+                let value = input.read_bytes_vec(len as usize)?;
 
                 ParamValue::Capability(
                     Capability{
@@ -145,7 +148,7 @@ pub fn parse_bgp_open_message(input: &mut DataBytes) -> Result<BgpOpenMessage, P
             }
             _ => {
                 // unsupported param, read as raw bytes
-                let bytes = input.read_n_bytes(parm_length as usize)?;
+                let bytes = input.read_bytes_vec(parm_length as usize)?;
                 ParamValue::Raw(bytes)
             }
         };
@@ -170,36 +173,39 @@ pub fn parse_bgp_open_message(input: &mut DataBytes) -> Result<BgpOpenMessage, P
 }
 
 /// read nlri portion of a bgp update message.
-fn read_nlri(input: &mut DataBytes, length: usize, afi: &Afi, add_path: bool) -> Result<Vec<NetworkPrefix>, ParserError> {
+fn read_nlri(input: &mut Cursor<&[u8]>, length: usize, afi: &Afi, add_path: bool) -> Result<Vec<NetworkPrefix>, ParserError> {
     if length==0{
         return Ok(vec![])
     }
     if length==1 {
         // 1 byte does not make sense
         warn!("seeing strange one-byte NLRI field");
-        input.read_8b().unwrap();
+        input.read_u8().unwrap();
         return Ok(vec![])
     }
 
-    let prefixes = input.parse_nlri_list(add_path, afi, length)?;
-
-    Ok(prefixes)
+    Ok(parse_nlri_list(input, add_path, afi, length as u64)?)
 }
 
 /// read bgp update message.
-pub fn parse_bgp_update_message(input: &mut DataBytes, add_path:bool, asn_len: &AsnLength, bgp_msg_length: u64) -> Result<BgpUpdateMessage, ParserError> {
+pub fn parse_bgp_update_message(input: &mut Cursor<&[u8]>, add_path:bool, asn_len: &AsnLength, bgp_msg_length: u64) -> Result<BgpUpdateMessage, ParserError> {
+
     // AFI for routes out side attributes are IPv4 ONLY.
     let afi = Afi::Ipv4;
 
     // parse withdrawn prefixes nlri
-    let withdrawn_length = input.read_16b()? as u64;
+    let withdrawn_length = input.read_u16::<BE>()? as u64;
     let withdrawn_prefixes = read_nlri(input, withdrawn_length as usize, &afi, add_path)?;
 
     // parse attributes
-    let attribute_length = input.read_16b()? as usize;
+    let attribute_length = input.read_u16::<BE>()? as usize;
     let attr_parser = AttributeParser::new(add_path);
 
-    let attributes = attr_parser.parse_attributes(input, asn_len, None, None, None, attribute_length)?;
+    let pos_start = input.position() as usize;
+    let pos_end = pos_start + attribute_length;
+    let attr_data_slice = &input.get_ref()[pos_start..pos_end];
+    let attributes = attr_parser.parse_attributes(attr_data_slice, asn_len, None, None, None)?;
+    input.seek(SeekFrom::Start(pos_end as u64))?;
 
     // parse announced prefixes nlri
     let nlri_length = bgp_msg_length - 4 - withdrawn_length - attribute_length as u64;

--- a/bgpkit-parser/src/parser/bmp/messages/headers.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/headers.rs
@@ -1,6 +1,5 @@
 use std::io::{Cursor, Seek, SeekFrom};
 use std::net::IpAddr;
-use byteorder::{BE, ReadBytesExt};
 use bgp_models::network::{Afi, AsnLength};
 use crate::parser::bmp::error::ParserBmpError;
 use num_traits::FromPrimitive;
@@ -54,15 +53,15 @@ pub struct BmpCommonHeader {
 
 pub fn parse_bmp_common_header(reader: &mut Cursor<&[u8]>) -> Result<BmpCommonHeader, ParserBmpError>{
 
-    let version = reader.read_u8()?;
+    let version = reader.read_8b()?;
     if version!=3 {
         // has to be 3 per rfc7854
         return Err(ParserBmpError::CorruptedBmpMessage)
     }
 
-    let msg_len = reader.read_u32::<BE>()?;
+    let msg_len = reader.read_32b()?;
 
-    let msg_type = BmpMsgType::from_u8(reader.read_u8()?).unwrap();
+    let msg_type = BmpMsgType::from_u8(reader.read_8b()?).unwrap();
     Ok(BmpCommonHeader{
         version,
         msg_len,
@@ -106,6 +105,7 @@ pub struct BmpPerPeerHeader {
     pub asn_len: AsnLength,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Primitive)]
 pub enum PeerType {
     GlobalInstancePeer=0,

--- a/bgpkit-parser/src/parser/bmp/messages/peer_down_notification.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/peer_down_notification.rs
@@ -1,5 +1,6 @@
+use std::io::Cursor;
 use crate::parser::bmp::error::ParserBmpError;
-use crate::parser::DataBytes;
+use crate::parser::ReadUtils;
 
 #[derive(Debug)]
 pub struct PeerDownNotification {
@@ -7,8 +8,9 @@ pub struct PeerDownNotification {
     pub data: Option<Vec<u8>>,
 }
 
-pub fn parse_peer_down_notification(reader: &mut DataBytes) -> Result<PeerDownNotification, ParserBmpError> {
+pub fn parse_peer_down_notification(reader: &mut Cursor<&[u8]>) -> Result<PeerDownNotification, ParserBmpError> {
     let reason = reader.read_8b()?;
+    let bytes_left = reader.get_ref().len() - (reader.position() as usize);
     let data: Option<Vec<u8>> = match reason {
         1 => {
             /*
@@ -16,7 +18,7 @@ pub fn parse_peer_down_notification(reader: &mut DataBytes) -> Result<PeerDownNo
             Reason is a BGP PDU containing a BGP NOTIFICATION message that
             would have been sent to the peer.
             */
-            Some(reader.read_n_bytes(reader.bytes_left())?)
+            Some(reader.read_bytes_vec(bytes_left)?)
         },
         2 => {
             /*
@@ -27,7 +29,7 @@ pub fn parse_peer_down_notification(reader: &mut DataBytes) -> Result<PeerDownNo
             Section 8.1 of [RFC4271]).  Two bytes both set to 0 are used to
             indicate that no relevant Event code is defined.
              */
-            Some(reader.read_n_bytes(reader.bytes_left())?)
+            Some(reader.read_bytes_vec(bytes_left)?)
         },
         3 => {
             /*
@@ -35,7 +37,7 @@ pub fn parse_peer_down_notification(reader: &mut DataBytes) -> Result<PeerDownNo
             message.  Following the Reason is a BGP PDU containing the BGP
             NOTIFICATION message as received from the peer.
              */
-            Some(reader.read_n_bytes(reader.bytes_left())?)
+            Some(reader.read_bytes_vec(bytes_left)?)
         },
         4 => {
             /*

--- a/bgpkit-parser/src/parser/bmp/messages/peer_up_notification.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/peer_up_notification.rs
@@ -1,9 +1,10 @@
+use std::io::{Cursor, Seek, SeekFrom};
 use std::net::IpAddr;
 use bgp_models::bgp::BgpOpenMessage;
 use bgp_models::network::Afi;
 use crate::parser::bgp::messages::parse_bgp_open_message;
 use crate::parser::bmp::error::ParserBmpError;
-use crate::parser::DataBytes;
+use crate::parser::ReadUtils;
 
 #[derive(Debug)]
 pub struct PeerUpNotification {
@@ -22,10 +23,10 @@ pub struct PeerUpNotificationTlv {
     pub info_value: String,
 }
 
-pub fn parse_peer_up_notification(reader: &mut DataBytes, afi: &Afi) -> Result<PeerUpNotification, ParserBmpError> {
+pub fn parse_peer_up_notification(reader: &mut Cursor<&[u8]>, afi: &Afi) -> Result<PeerUpNotification, ParserBmpError> {
     let local_addr: IpAddr = match afi {
         Afi::Ipv4 => {
-            reader.read_and_drop_n_bytes(12)?;
+            reader.seek(SeekFrom::Current(12))?;
             let ip= reader.read_ipv4_address()?;
             ip.into()
         }
@@ -36,10 +37,12 @@ pub fn parse_peer_up_notification(reader: &mut DataBytes, afi: &Afi) -> Result<P
 
     let local_port = reader.read_16b()?;
     let remote_port = reader.read_16b()?;
+
     let sent_open = parse_bgp_open_message(reader)?;
     let received_open = parse_bgp_open_message(reader)?;
     let mut tlvs = vec![];
-    while reader.bytes_left()>=4 {
+    let total = reader.get_ref().len() as u64;
+    while total - reader.position() >=4 {
         let info_type = reader.read_16b()?;
         let info_len = reader.read_16b()?;
         let info_value = reader.read_n_bytes_to_string(info_len as usize)?;

--- a/bgpkit-parser/src/parser/bmp/messages/route_mirroring.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/route_mirroring.rs
@@ -1,9 +1,10 @@
+use std::io::Cursor;
 use bgp_models::bgp::BgpUpdateMessage;
 use bgp_models::network::AsnLength;
 use crate::parser::bgp::messages::parse_bgp_update_message;
 use crate::parser::bmp::error::ParserBmpError;
 use num_traits::FromPrimitive;
-use crate::parser::DataBytes;
+use crate::parser::ReadUtils;
 
 #[derive(Debug)]
 pub struct RouteMirroring {
@@ -28,15 +29,15 @@ pub enum RouteMirroringInfo {
     MessageLost=1,
 }
 
-pub fn parse_route_mirroring(reader: &mut DataBytes, asn_len: &AsnLength) -> Result<RouteMirroring, ParserBmpError> {
+pub fn parse_route_mirroring(reader: &mut Cursor<&[u8]>, asn_len: &AsnLength) -> Result<RouteMirroring, ParserBmpError> {
     let mut tlvs = vec![];
-    while reader.bytes_left() > 4 {
+    while reader.get_ref().len() - (reader.position() as usize) > 4 {
         match reader.read_16b()? {
             0 => {
                 let info_len = reader.read_16b()?;
-                let bytes = reader.read_n_bytes(info_len as usize)?;
-                let mut data = DataBytes::new(&bytes);
-                let value = parse_bgp_update_message(&mut data, false, asn_len, info_len as u64)?;
+                let bytes = reader.read_bytes_vec(info_len as usize)?;
+                let mut reader = Cursor::new(bytes.as_slice());
+                let value = parse_bgp_update_message(&mut reader, false, asn_len, info_len as u64)?;
                 tlvs.push(RouteMirroringTlv{ info_len, value: RouteMirroringValue::BgpMessage(value)});
             }
             1 => {

--- a/bgpkit-parser/src/parser/bmp/messages/route_monitoring.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/route_monitoring.rs
@@ -2,16 +2,15 @@ use bgp_models::bgp::BgpMessage;
 use bgp_models::network::AsnLength;
 use crate::parser::bgp::messages::parse_bgp_message;
 use crate::parser::bmp::error::ParserBmpError;
-use crate::parser::DataBytes;
 
 #[derive(Debug)]
 pub struct RouteMonitoring {
     pub bgp_message: BgpMessage
 }
 
-pub fn parse_route_monitoring(reader: &mut DataBytes, asn_len: &AsnLength) -> Result<RouteMonitoring, ParserBmpError> {
+pub fn parse_route_monitoring(data: &[u8], asn_len: &AsnLength) -> Result<RouteMonitoring, ParserBmpError> {
     // let bgp_update = parse_bgp_update_message(reader, false, afi, asn_len, total_len)?;
-    let bgp_update = parse_bgp_message(reader, false, asn_len, reader.bytes_left())?;
+    let bgp_update = parse_bgp_message(data, false, asn_len)?;
     Ok(RouteMonitoring{
         bgp_message: bgp_update
     })

--- a/bgpkit-parser/src/parser/bmp/messages/stats_report.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/stats_report.rs
@@ -1,5 +1,6 @@
+use std::io::Cursor;
 use crate::parser::bmp::error::ParserBmpError;
-use crate::parser::DataBytes;
+use crate::parser::ReadUtils;
 
 #[derive(Debug)]
 pub struct StatsReport {
@@ -20,7 +21,7 @@ pub enum StatsData {
     Gauge(u64),
 }
 
-pub fn parse_stats_report(reader: &mut DataBytes) -> Result<StatsReport, ParserBmpError> {
+pub fn parse_stats_report(reader: &mut Cursor<&[u8]>) -> Result<StatsReport, ParserBmpError> {
     let stats_count = reader.read_32b()?;
     let mut counters = vec![];
     for _ in 0..stats_count {

--- a/bgpkit-parser/src/parser/bmp/mod.rs
+++ b/bgpkit-parser/src/parser/bmp/mod.rs
@@ -1,10 +1,10 @@
 /*!
 Provides parsing for BMP and OpenBMP binary-formatted messages.
 */
+use std::io::Cursor;
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::bmp::messages::*;
 pub use crate::parser::bmp::openbmp::parse_openbmp_header;
-use crate::parser::DataBytes;
 
 pub mod openbmp;
 pub mod error;
@@ -13,13 +13,14 @@ pub mod messages;
 /// Parse OpenBMP `raw_bmp` message.
 ///
 /// An OpenBMP `raw_bmp` message contains a [OpenBmpHeader] and a [BmpMessage].
-pub fn parse_openbmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpError> {
-    let _header = parse_openbmp_header(reader)?;
-    parse_bmp_msg(reader)
+pub fn parse_openbmp_msg(data: &[u8]) -> Result<BmpMessage, ParserBmpError> {
+    let mut reader = Cursor::new(data);
+    let _header = parse_openbmp_header(&mut reader)?;
+    parse_bmp_msg(&mut reader)
 }
 
 /// Parse a BMP message.
-pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpError>{
+pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmpError>{
     let common_header = parse_bmp_common_header(reader)?;
 
     // let mut buffer ;
@@ -34,11 +35,12 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
     //     return Err(ParserBmpError::CorruptedBmpMessage)
     // };
     // reader.read_exact(&mut buffer)?;
-    let data_bytes = reader;
 
     match &common_header.msg_type{
         BmpMsgType::RouteMonitoring => {
-            let per_peer_header = parse_per_peer_header(data_bytes)?;
+            let per_peer_header = parse_per_peer_header(reader)?;
+            let pos_start = reader.position() as usize;
+            let data_bytes = &reader.get_ref()[pos_start..];
             let msg = parse_route_monitoring(data_bytes,
                                              &per_peer_header.asn_len)?;
             Ok(
@@ -50,8 +52,8 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::RouteMirroringMessage => {
-            let per_peer_header = parse_per_peer_header(data_bytes)?;
-            let msg = parse_route_mirroring(data_bytes, &per_peer_header.asn_len)?;
+            let per_peer_header = parse_per_peer_header(reader)?;
+            let msg = parse_route_mirroring(reader, &per_peer_header.asn_len)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -61,8 +63,8 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::StatisticsReport => {
-            let per_peer_header = parse_per_peer_header(data_bytes)?;
-            let msg = parse_stats_report(data_bytes)?;
+            let per_peer_header = parse_per_peer_header(reader)?;
+            let msg = parse_stats_report(reader)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -72,8 +74,8 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::PeerDownNotification => {
-            let per_peer_header = parse_per_peer_header(data_bytes)?;
-            let msg = parse_peer_down_notification(data_bytes)?;
+            let per_peer_header = parse_per_peer_header(reader)?;
+            let msg = parse_peer_down_notification(reader)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -84,8 +86,8 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::PeerUpNotification => {
-            let per_peer_header = parse_per_peer_header(data_bytes)?;
-            let msg = parse_peer_up_notification(data_bytes, &per_peer_header.afi)?;
+            let per_peer_header = parse_per_peer_header(reader)?;
+            let msg = parse_peer_up_notification(reader, &per_peer_header.afi)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -95,7 +97,7 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::InitiationMessage => {
-            let msg = parse_initiation_message(data_bytes)?;
+            let msg = parse_initiation_message(reader)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -105,7 +107,7 @@ pub fn parse_bmp_msg(reader: &mut DataBytes) -> Result<BmpMessage, ParserBmpErro
             )
         }
         BmpMsgType::TerminationMessage => {
-            let msg = parse_termination_message(data_bytes)?;
+            let msg = parse_termination_message(reader)?;
             Ok(
                 BmpMessage{
                     common_header,
@@ -127,7 +129,7 @@ mod tests {
     fn test_peer_down_notification() {
         let input = "4f424d500107006400000033800c6184b9c2000c602cbf4f072f3ae149d23486024bc3dadfc4000a69732d63632d626d7031c677060bdd020a9e92be000200de2e3180df3369000000000000000000000000000c726f7574652d76696577733500000001030000003302000000000000000000000000000000000000000000003fda060e00000da30000000061523c36000c0e1c0200000a";
         let decoded = hex::decode(input).unwrap();
-        let mut reader = DataBytes::new(&decoded);
+        let mut reader = Cursor::new(decoded.as_slice());
         let _header = parse_openbmp_header(&mut reader).unwrap();
         let msg = parse_bmp_msg(&mut reader).unwrap();
         dbg!(msg);
@@ -137,7 +139,7 @@ mod tests {
     fn test_route_monitoring() {
         let input = "4f424d500107005c000000b0800c618881530002f643fef880938d19e9d632c815d1e95a87e1000a69732d61682d626d7031eb4de4e596b282c6a995b067df4abc8cc342f19200000000000000000000000000046c696e780000000103000000b00000c00000000000000000200107f800040000000000001aae000400001aae5474800e02dddf5d00000000ffffffffffffffffffffffffffffffff00800200000069400101005002001602050000192f00001aae0000232a000328eb00032caec008181aae42681aae44581aae464f1aae59d91aae866543000000900e002c00020120200107f800040000000000001aae0004fe8000000000000082711ffffe7f29f100302a0fca8000010a";
         let decoded = hex::decode(input).unwrap();
-        let mut reader = DataBytes::new(&decoded);
+        let mut reader = Cursor::new(decoded.as_slice());
         let _header = parse_openbmp_header(&mut reader).unwrap();
         let msg = parse_bmp_msg(&mut reader).unwrap();
         dbg!(msg);

--- a/bgpkit-parser/src/parser/bmp/openbmp.rs
+++ b/bgpkit-parser/src/parser/bmp/openbmp.rs
@@ -1,6 +1,5 @@
 use std::io::{Cursor, Seek, SeekFrom};
 use std::net::IpAddr;
-use byteorder::{BE, ReadBytesExt};
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::ReadUtils;
 
@@ -66,8 +65,8 @@ pub fn parse_openbmp_header(reader: &mut Cursor<&[u8]>) -> Result<OpenBmpHeader,
     }
 
     // read version numbers
-    let version_major = reader.read_u8()?;
-    let version_minor = reader.read_u8()?;
+    let version_major = reader.read_8b()?;
+    let version_minor = reader.read_8b()?;
     if (version_major, version_minor) != (1,7) {
         return Err(ParserBmpError::InvalidOpenBmpHeader)
     }
@@ -77,21 +76,21 @@ pub fn parse_openbmp_header(reader: &mut Cursor<&[u8]>) -> Result<OpenBmpHeader,
     let msg_len = reader.read_32b()?;
 
     // read flags
-    let flags = reader.read_u8()?;
+    let flags = reader.read_8b()?;
     let (is_router_msg, is_router_ipv6) = (flags&0x80!=0, flags&0x40!=0);
     if !is_router_msg {
         return Err(ParserBmpError::UnsupportedOpenBmpMessage)
     }
 
     // read object type
-    let object_type = reader.read_u8()?;
+    let object_type = reader.read_8b()?;
     if object_type != 12 {
         return Err(ParserBmpError::UnsupportedOpenBmpMessage)
     }
 
     // read_timestamp
-    let t_sec = reader.read_u32::<BE>()?;
-    let t_usec = reader.read_u32::<BE>()?;
+    let t_sec = reader.read_32b()?;
+    let t_usec = reader.read_32b()?;
     let timestamp = t_sec as f64 + (t_usec as f64)/1_000_000.0;
 
     // read admin-id

--- a/bgpkit-parser/src/parser/iters.rs
+++ b/bgpkit-parser/src/parser/iters.rs
@@ -79,7 +79,7 @@ impl Iterator for RecordIterator {
                                 warn!("parser warn: {}", err_str);
                             }
                             if let Some(bytes) = e.bytes {
-                                std::fs::write("mrt_cord_dump", bytes).expect("Unable to write to mrt_core_dump");
+                                std::fs::write("mrt_core_dump", bytes).expect("Unable to write to mrt_core_dump");
                             }
                             continue
                         }

--- a/bgpkit-parser/src/parser/iters.rs
+++ b/bgpkit-parser/src/parser/iters.rs
@@ -1,6 +1,7 @@
 /*!
 Provides parser iterator implementation.
 */
+use std::io::Read;
 use log::{error, warn};
 use bgp_models::mrt::{MrtMessage, MrtRecord, TableDumpV2Message};
 use crate::{BgpElem, Elementor};
@@ -9,20 +10,20 @@ use crate::parser::BgpkitParser;
 use crate::Filterable;
 
 /// Use [BgpElemIterator] as the default iterator to return [BgpElem]s instead of [MrtRecord]s.
-impl IntoIterator for BgpkitParser {
+impl<R: Read> IntoIterator for BgpkitParser<R> {
     type Item = BgpElem;
-    type IntoIter = ElemIterator;
+    type IntoIter = ElemIterator<R>;
 
     fn into_iter(self) -> Self::IntoIter {
         ElemIterator::new(self)
     }
 }
 
-impl BgpkitParser {
-    pub fn into_record_iter(self) -> RecordIterator {
+impl<R> BgpkitParser<R> {
+    pub fn into_record_iter(self) -> RecordIterator<R> {
         RecordIterator::new(self)
     }
-    pub fn into_elem_iter(self) -> ElemIterator {
+    pub fn into_elem_iter(self) -> ElemIterator<R> {
         ElemIterator::new(self)
     }
 }
@@ -32,21 +33,21 @@ MrtRecord Iterator
 **********/
 
 
-pub struct RecordIterator {
-    pub parser: BgpkitParser,
+pub struct RecordIterator<R> {
+    pub parser: BgpkitParser<R>,
     pub count: u64,
     elementor: Elementor,
 }
 
-impl RecordIterator {
-    fn new(parser: BgpkitParser) -> RecordIterator {
+impl<R> RecordIterator<R> {
+    fn new(parser: BgpkitParser<R>) -> Self {
         RecordIterator {
             parser , count: 0, elementor: Elementor::new()
         }
     }
 }
 
-impl Iterator for RecordIterator {
+impl<R: Read> Iterator for RecordIterator<R> {
     type Item = MrtRecord;
 
     fn next(&mut self) -> Option<MrtRecord> {
@@ -123,20 +124,20 @@ impl Iterator for RecordIterator {
 BgpElem Iterator
 **********/
 
-pub struct ElemIterator {
+pub struct ElemIterator<R> {
     cache_elems: Vec<BgpElem>,
-    record_iter: RecordIterator,
+    record_iter: RecordIterator<R>,
     elementor: Elementor,
     count: u64,
 }
 
-impl ElemIterator {
-    fn new(parser: BgpkitParser) -> ElemIterator {
+impl<R> ElemIterator<R> {
+    fn new(parser: BgpkitParser<R>) -> Self {
         ElemIterator { record_iter: RecordIterator::new(parser) , count: 0 , cache_elems: vec![], elementor: Elementor::new()}
     }
 }
 
-impl Iterator for ElemIterator {
+impl<R: Read> Iterator for ElemIterator<R> {
     type Item = BgpElem;
 
     fn next(&mut self) -> Option<BgpElem> {

--- a/bgpkit-parser/src/parser/mod.rs
+++ b/bgpkit-parser/src/parser/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2
 
 pub use crate::error::{ParserErrorWithBytes, ParserError};
 pub use mrt::mrt_elem::Elementor;
-use bgp_models::prelude::{ElemType, MrtRecord};
+use bgp_models::prelude::MrtRecord;
 use oneio::get_reader;
 use crate::Filter;
 

--- a/bgpkit-parser/src/parser/mod.rs
+++ b/bgpkit-parser/src/parser/mod.rs
@@ -19,8 +19,8 @@ use bgp_models::prelude::MrtRecord;
 use oneio::get_reader;
 use crate::Filter;
 
-pub struct BgpkitParser {
-    reader: Box<dyn Read + Send>,
+pub struct BgpkitParser<R> {
+    reader: R,
     core_dump: bool,
     filters: Vec<Filter>,
     options: ParserOptions
@@ -37,9 +37,9 @@ impl Default for ParserOptions {
     }
 }
 
-impl BgpkitParser {
+impl BgpkitParser<Box<dyn Read + Send>> {
     /// Creating a new parser from a object that implements [Read] trait.
-    pub fn new(path: &str) -> Result<BgpkitParser, ParserErrorWithBytes>{
+    pub fn new(path: &str) -> Result<Self, ParserErrorWithBytes> {
         let reader = get_reader(path)?;
         Ok(
             BgpkitParser{
@@ -50,18 +50,27 @@ impl BgpkitParser {
             }
         )
     }
+}
 
+impl<R: Read> BgpkitParser<R> {
     /// Creating a new parser from a object that implements [Read] trait.
-    pub fn from_reader(reader: Box<dyn Read + Send>) -> Self {
-        BgpkitParser{
-            reader: Box::new(reader),
+    pub fn from_reader(reader: R) -> Self {
+        BgpkitParser {
+            reader,
             core_dump: false,
             filters: vec![],
             options: ParserOptions::default()
         }
     }
 
-    pub fn enable_core_dump(self) -> BgpkitParser {
+    /// This is used in for loop `for item in parser{}`
+    pub fn next_record(&mut self) -> Result<MrtRecord, ParserErrorWithBytes> {
+        parse_mrt_record(&mut self.reader)
+    }
+}
+
+impl<R> BgpkitParser<R> {
+    pub fn enable_core_dump(self) -> Self {
         BgpkitParser{
             reader: self.reader,
             core_dump: true,
@@ -70,7 +79,7 @@ impl BgpkitParser {
         }
     }
 
-    pub fn disable_warnings(self) -> BgpkitParser {
+    pub fn disable_warnings(self) -> Self {
         let mut options = self.options;
         options.show_warnings = false;
         BgpkitParser{
@@ -81,7 +90,7 @@ impl BgpkitParser {
         }
     }
 
-    pub fn add_filter(self, filter_type: &str, filter_value: &str) -> Result<BgpkitParser, ParserErrorWithBytes> {
+    pub fn add_filter(self, filter_type: &str, filter_value: &str) -> Result<Self, ParserErrorWithBytes> {
         let mut filters = self.filters;
         filters.push(Filter::new(filter_type, filter_value)?);
         Ok(
@@ -92,11 +101,6 @@ impl BgpkitParser {
                 options: self.options
             }
         )
-    }
-
-    /// This is used in for loop `for item in parser{}`
-    pub fn next_record(&mut self) -> Result<MrtRecord, ParserErrorWithBytes> {
-        parse_mrt_record(&mut self.reader)
     }
 }
 
@@ -110,9 +114,7 @@ mod tests {
         // bzip2 reader for compressed file
         let http_stream = ureq::get("http://archive.routeviews.org/route-views.ny/bgpdata/2023.02/UPDATES/updates.20230215.0630.bz2")
             .call().unwrap().into_reader();
-        let reader = Box::new(
-            bzip2::read::BzDecoder::new(http_stream)
-        );
+        let reader = bzip2::read::BzDecoder::new(http_stream);
         assert_eq!(12683, BgpkitParser::from_reader(reader).into_elem_iter().count());
 
         // remote reader for uncompressed updates file

--- a/bgpkit-parser/src/parser/mrt/messages/table_dump_message.rs
+++ b/bgpkit-parser/src/parser/mrt/messages/table_dump_message.rs
@@ -81,8 +81,8 @@ pub fn parse_table_dump_message(
         Afi::Ipv4 => input.read_ipv4_prefix().map(ipnet::IpNet::V4),
         Afi::Ipv6 => input.read_ipv6_prefix().map(ipnet::IpNet::V6),
     }?;
-    let status = input.read_u8()?;
-    let time = input.read_u32::<BE>()? as u64;
+    let status = input.read_8b()?;
+    let time = input.read_32b()? as u64;
 
     let peer_address: IpAddr = input.read_address(&afi)?;
     let peer_asn = input.read_asn(&asn_len)?;

--- a/bgpkit-parser/src/parser/mrt/messages/table_dump_v2_message.rs
+++ b/bgpkit-parser/src/parser/mrt/messages/table_dump_v2_message.rs
@@ -1,15 +1,30 @@
 use std::collections::HashMap;
+use std::io::{Cursor, Seek, SeekFrom};
 use crate::error::ParserError;
 use std::net::{IpAddr, Ipv4Addr};
+use byteorder::{BE, ReadBytesExt};
 use bgp_models::mrt::tabledump::{Peer, PeerIndexTable, RibAfiEntries, RibEntry, TableDumpV2Message, TableDumpV2Type};
 use bgp_models::network::*;
 use log::warn;
 use num_traits::FromPrimitive;
-use crate::parser::{AttributeParser, DataBytes};
+use crate::parser::{AttributeParser, ReadUtils};
 
+/// Parse TABLE_DUMP V2 format MRT message.
+///
+/// RFC: https://www.rfc-editor.org/rfc/rfc6396#section-4.3
+///
+/// Subtypes include
+/// 1. PEER_INDEX_TABLE
+/// 2. RIB_IPV4_UNICAST
+/// 3. RIB_IPV4_MULTICAST
+/// 4. RIB_IPV6_UNICAST
+/// 5. RIB_IPV6_MULTICAST
+/// 6. RIB_GENERIC
+///
 pub fn parse_table_dump_v2_message(
     sub_type: u16,
-    input: &mut DataBytes) -> Result<TableDumpV2Message, ParserError> {
+    input: &[u8]
+) -> Result<TableDumpV2Message, ParserError> {
 
     let v2_type: TableDumpV2Type = match TableDumpV2Type::from_u16(sub_type) {
         Some(t) => t,
@@ -18,6 +33,7 @@ pub fn parse_table_dump_v2_message(
 
     let msg: TableDumpV2Message = match v2_type {
         TableDumpV2Type:: PeerIndexTable => {
+            // peer index table type
             TableDumpV2Message::PeerIndexTable (parse_peer_index_table(input)?)
         },
         TableDumpV2Type:: RibIpv4Unicast|TableDumpV2Type::RibIpv4Multicast|
@@ -36,18 +52,20 @@ pub fn parse_table_dump_v2_message(
 
 /// Peer index table
 ///
-/// https://tools.ietf.org/html/rfc6396#section-4.3
-pub fn parse_peer_index_table(input: &mut DataBytes) -> Result<PeerIndexTable, ParserError> {
-    let collector_bgp_id = Ipv4Addr::from(input.read_32b()?);
-    // read and ignore view name
-    let view_name_length = input.read_16b()?;
-    // TODO: properly parse view_name
-    input.read_and_drop_n_bytes(view_name_length as usize)?;
+/// RFC: https://www.rfc-editor.org/rfc/rfc6396#section-4.3.1
+pub fn parse_peer_index_table(data: &[u8]) -> Result<PeerIndexTable, ParserError> {
+    let mut input = Cursor::new(data);
 
-    let peer_count = input.read_16b()?;
+    let collector_bgp_id = Ipv4Addr::from(input.read_u32::<BE>()?);
+    // read and ignore view name
+    let view_name_length = input.read_u16::<BE>()?;
+    // TODO: properly parse view_name
+    input.seek(SeekFrom::Current(view_name_length as i64))?;
+
+    let peer_count = input.read_u16::<BE>()?;
     let mut peers = vec![];
     for _index in 0..peer_count {
-        let peer_type = input.read_8b()?;
+        let peer_type = input.read_u8()?;
         let afi = match peer_type & 1 {
             1 => Afi::Ipv6,
             _ => Afi::Ipv4,
@@ -57,7 +75,7 @@ pub fn parse_peer_index_table(input: &mut DataBytes) -> Result<PeerIndexTable, P
             _ => AsnLength::Bits16,
         };
 
-        let peer_bgp_id = Ipv4Addr::from(input.read_32b()?);
+        let peer_bgp_id = Ipv4Addr::from(input.read_u32::<BE>()?);
         let peer_address: IpAddr = input.read_address(&afi)?;
         let peer_asn = input.read_asn(&asn_len)?;
         peers.push(Peer{
@@ -88,7 +106,9 @@ pub fn parse_peer_index_table(input: &mut DataBytes) -> Result<PeerIndexTable, P
 /// RIB AFI-specific entries
 ///
 /// https://tools.ietf.org/html/rfc6396#section-4.3
-pub fn parse_rib_afi_entries(input: &mut DataBytes, rib_type: TableDumpV2Type) -> Result<RibAfiEntries, ParserError> {
+pub fn parse_rib_afi_entries(data: &[u8], rib_type: TableDumpV2Type) -> Result<RibAfiEntries, ParserError> {
+    let mut input = Cursor::new(data);
+
     let afi: Afi;
     let safi: Safi;
     match rib_type {
@@ -116,18 +136,21 @@ pub fn parse_rib_afi_entries(input: &mut DataBytes, rib_type: TableDumpV2Type) -
     let add_path = matches!(rib_type, TableDumpV2Type::RibIpv4UnicastAddPath | TableDumpV2Type::RibIpv4MulticastAddPath |
         TableDumpV2Type::RibIpv6UnicastAddPath | TableDumpV2Type::RibIpv6MulticastAddPath);
 
-    let sequence_number = input.read_32b()?;
+    let sequence_number = input.read_u32::<BE>()?;
 
     // NOTE: here we parse the prefix as only length and prefix, the path identifier for add_path
     //       entry is not handled here. We follow RFC6396 here https://www.rfc-editor.org/rfc/rfc6396.html#section-4.3.2
     let prefix = input.read_nlri_prefix(&afi, false)?;
     let prefixes = vec!(prefix);
 
-    let entry_count = input.read_16b()?;
+    let entry_count = input.read_u16::<BE>()?;
     let mut rib_entries = Vec::with_capacity((entry_count*2) as usize);
 
+    // get the u8 slice of the rest of the data
+    // let attr_data_slice = &input.into_inner()[(input.position() as usize)..];
+
     for _i in 0..entry_count {
-        let entry = match parse_rib_entry(input, add_path, &afi, &safi, &prefixes) {
+        let entry = match parse_rib_entry(&mut input, add_path, &afi, &safi, &prefixes) {
             Ok(entry) => entry,
             Err(e) => {
                 warn!("early break due to error {}", e.to_string());
@@ -147,24 +170,37 @@ pub fn parse_rib_afi_entries(input: &mut DataBytes, rib_type: TableDumpV2Type) -
     )
 }
 
-pub fn parse_rib_entry(input: &mut DataBytes, add_path: bool, afi: &Afi, safi: &Safi, prefixes: &[NetworkPrefix]) -> Result<RibEntry, ParserError> {
-    if input.bytes_left() < 16 {
+pub fn parse_rib_entry(input: &mut Cursor<&[u8]>, add_path: bool, afi: &Afi, safi: &Safi, prefixes: &[NetworkPrefix]) -> Result<RibEntry, ParserError> {
+    // TODO: fix the implementation here
+    let mut total_bytes_left = input.get_ref().len() - (input.position() as usize);
+    if  total_bytes_left < 8 {
+        // total length - current position less than 16 --
+        // meaning less than 16 bytes available to read
         return Err(ParserError::TruncatedMsg("truncated msg".to_string()))
     }
-    let peer_index = input.read_16b()?;
-    let originated_time = input.read_32b()?;
-    if add_path {
-        let _path_id = input.read_32b()?;
-    }
-    let attribute_length = input.read_16b()? as usize;
 
-    if input.bytes_left() < attribute_length  {
+    let peer_index = input.read_u16::<BE>()?;
+    let originated_time = input.read_u32::<BE>()?;
+    total_bytes_left -= 6;
+    if add_path {
+        let _path_id = input.read_u32::<BE>()?;
+        total_bytes_left -= 4;
+    }
+    let attribute_length = input.read_u16::<BE>()? as usize;
+    total_bytes_left -= 2;
+
+    // TODO: fix the implementation here
+    if total_bytes_left < attribute_length  {
         return Err(ParserError::TruncatedMsg("truncated msg".to_string()))
     }
 
     let attr_parser = AttributeParser::new(add_path);
 
-    let attributes = attr_parser.parse_attributes(input, &AsnLength::Bits32, Some(*afi), Some(*safi), Some(prefixes), attribute_length)?;
+    let pos = input.position() as usize;
+    let pos_end = pos + attribute_length;
+    let attr_data_slice = &input.get_ref()[pos .. pos_end];
+    let attributes = attr_parser.parse_attributes(attr_data_slice, &AsnLength::Bits32, Some(*afi), Some(*safi), Some(prefixes))?;
+    input.seek(SeekFrom::Start(pos_end as u64))?;
 
     Ok(
         RibEntry{

--- a/bgpkit-parser/src/parser/mrt/mrt_elem.rs
+++ b/bgpkit-parser/src/parser/mrt/mrt_elem.rs
@@ -27,6 +27,7 @@ macro_rules! get_attr_value {
     };
 }
 
+#[allow(clippy::type_complexity)]
 fn get_relevant_attributes(
     attributes: Vec<Attribute>,
 ) -> (

--- a/bgpkit-parser/src/parser/mrt/mrt_record.rs
+++ b/bgpkit-parser/src/parser/mrt/mrt_record.rs
@@ -1,6 +1,6 @@
 use std::io::{ErrorKind, Read};
 use bgp_models::mrt::{CommonHeader, EntryType, MrtMessage, MrtRecord};
-use crate::parser::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message, ParserErrorWithBytes};
+use crate::parser::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message, ParserErrorWithBytes, ReadUtils};
 use crate::error::ParserError;
 use num_traits::FromPrimitive;
 use byteorder::{BE, ReadBytesExt};
@@ -40,7 +40,7 @@ use byteorder::{BE, ReadBytesExt};
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 pub fn parse_common_header<T: Read>(input: &mut T) -> Result<(Vec<u8>, CommonHeader), ParserError> {
-    let timestamp = match input.read_u32::<BE>()  {
+    let timestamp = match input.read_32b()  {
         Ok(t) => {t}
         Err(e) => {
             return match e.kind() {
@@ -62,11 +62,11 @@ pub fn parse_common_header<T: Read>(input: &mut T) -> Result<(Vec<u8>, CommonHea
         )),
     }?;
     let entry_subtype = input.read_u16::<BE>()?;
-    let mut length = input.read_u32::<BE>()?;
+    let mut length = input.read_32b()?;
     let microsecond_timestamp = match &entry_type {
         EntryType::BGP4MP_ET => {
             length -= 4;
-            Some(input.read_u32::<BE>()?)
+            Some(input.read_32b()?)
 
         },
         _ => None,

--- a/bgpkit-parser/src/parser/rislive/messages/raw_bytes.rs
+++ b/bgpkit-parser/src/parser/rislive/messages/raw_bytes.rs
@@ -40,7 +40,7 @@ pub fn parse_raw_bytes(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisliveError
     let bgp_msg = match parse_bgp_message(bytes.as_slice(), false, &AsnLength::Bits32) {
         Ok(m) => {m}
         Err(_) => {
-            match parse_bgp_message(&bytes.as_slice(), false, &AsnLength::Bits16) {
+            match parse_bgp_message(bytes.as_slice(), false, &AsnLength::Bits16) {
                 Ok(m) => {m}
                 Err(_) => {return Err(ParserRisliveError::IncorrectRawBytes)}
             }

--- a/bgpkit-parser/src/parser/rislive/mod.rs
+++ b/bgpkit-parser/src/parser/rislive/mod.rs
@@ -47,9 +47,8 @@ use std::net::IpAddr;
 use ipnet::IpNet;
 use bgp_models::bgp::community::Community;
 use bgp_models::bgp::attributes::Origin::{EGP, IGP, INCOMPLETE};
-use bgp_models::bgp::MetaCommunity;
+use bgp_models::bgp::{ElemType, MetaCommunity};
 use bgp_models::network::{Asn, NetworkPrefix};
-use crate::parser::ElemType;
 
 pub mod error;
 pub mod messages;

--- a/bgpkit-parser/src/parser/utils.rs
+++ b/bgpkit-parser/src/parser/utils.rs
@@ -6,166 +6,40 @@ use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr},
 };
-use std::convert::TryInto;
+use std::io::{Cursor, Seek, SeekFrom};
 
 use num_traits::FromPrimitive;
 use std::net::IpAddr;
+use byteorder::{BE, ReadBytesExt};
 use bgp_models::network::{Afi, Asn, AsnLength, NetworkPrefix, Safi};
 use log::debug;
 
 use crate::error::ParserError;
 
-pub struct DataBytes<'input> {
-    pub bytes: &'input [u8],
-    pub pos: usize,
-    pub total: usize,
-}
-
 // Allow reading IPs from Reads
-impl  DataBytes <'_>{
+pub trait ReadUtils: io::Read {
 
-    pub fn new(data: &Vec<u8>) -> DataBytes{
-        DataBytes{
-            bytes: data.as_slice(),
-            pos: 0,
-            total: data.len(),
-        }
+    fn read_8b(&mut self) -> io::Result<u8> {
+        self.read_u8()
     }
 
-    #[inline]
-    pub fn bytes_left(&self) -> usize {
-        self.total - self.pos
+    fn read_16b(&mut self) -> io::Result<u16> {
+        self.read_u16::<BE>()
     }
 
-    #[inline]
-    pub fn read_128b(&mut self) -> Result<u128, ParserError> {
-        let len = 16;
-        if self.total - self.pos < len {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += len;
-        Ok( u128::from_be_bytes(self.bytes[self.pos-len..self.pos].try_into().unwrap()) )
+    fn read_32b(&mut self) -> io::Result<u32> {
+        self.read_u32::<BE>()
     }
 
-    #[inline]
-    pub fn read_64b(&mut self) -> Result<u64, ParserError> {
-        let len = 8;
-        if self.total - self.pos < len {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += len;
-        Ok( u64::from_be_bytes(self.bytes[self.pos-len..self.pos].try_into().unwrap()) )
+    fn read_64b(&mut self) -> io::Result<u64> {
+        self.read_u64::<BE>()
     }
 
-    #[inline]
-    pub fn read_32b(&mut self) -> Result<u32, ParserError> {
-        let len = 4;
-        if self.total - self.pos < len {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += len;
-        Ok( u32::from_be_bytes(self.bytes[self.pos-len..self.pos].try_into().unwrap()) )
+    fn read_128b(&mut self) -> io::Result<u128> {
+        self.read_u128::<BE>()
     }
 
-    #[inline]
-    pub fn read_16b(&mut self) -> Result<u16, ParserError> {
-        let len = 2;
-        if self.total - self.pos < len {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += len;
-        Ok( u16::from_be_bytes(self.bytes[self.pos-len..self.pos].try_into().unwrap()) )
-    }
-
-    #[inline]
-    pub fn read_8b(&mut self) -> Result<u8, ParserError> {
-        let len = 1;
-        if self.total - self.pos < len {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += len;
-        Ok( self.bytes[self.pos-len] )
-    }
-
-    pub fn read_n_bytes(&mut self, n_bytes: usize) -> Result<Vec<u8>, ParserError>{
-        if self.total - self.pos < n_bytes {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos += n_bytes;
-        Ok(self.bytes[self.pos-n_bytes..self.pos].to_vec())
-    }
-
-    pub fn read_n_bytes_to_string(&mut self, n_bytes: usize) -> Result<String, ParserError>{
-        let buffer = self.read_n_bytes(n_bytes)?;
-        Ok(buffer.into_iter().map(|x:u8| x as char).collect::<String>())
-    }
-
-    pub fn read_and_drop_n_bytes(&mut self, n_bytes: usize) -> Result<(), ParserError>{
-        if self.total - self.pos < n_bytes {
-            return Err(ParserError::IoNotEnoughBytes())
-        }
-        self.pos+=n_bytes;
-        Ok(())
-    }
-
-    pub fn fast_forward(&mut self, to: usize) {
-        self.pos = to;
-    }
-
-    /// Read announced/withdrawn prefix.
-    ///
-    /// The length in bits is 1 byte, and then based on the IP version it reads different number of bytes.
-    /// If the `add_path` is true, it will also first read a 4-byte path id first; otherwise, a path-id of 0
-    /// is automatically set.
-    pub fn read_nlri_prefix(&mut self, afi: &Afi, add_path: bool) -> Result<NetworkPrefix, ParserError> {
-
-        let path_id = if add_path {
-            self.read_32b()?
-        } else {
-            0
-        };
-
-        // Length in bits
-        let bit_len = self.read_8b()?;
-
-        // Convert to bytes
-        let byte_len: usize = (bit_len as usize + 7) / 8;
-        let addr:IpAddr = match afi {
-            Afi::Ipv4 => {
-
-                // 4 bytes -- u32
-                if byte_len>4 {
-                    return Err(ParserError::ParseError(format!("Invalid byte length for IPv4 prefix. byte_len: {}, bit_len: {}", byte_len, bit_len)))
-                }
-                let mut buff = [0; 4];
-                for i in 0..byte_len {
-                    buff[i] = self.read_8b()?
-                }
-                IpAddr::V4(Ipv4Addr::from(buff))
-            }
-            Afi::Ipv6 => {
-                // 16 bytes
-                if byte_len>16 {
-                    return Err(ParserError::ParseError(format!("Invalid byte length for IPv6 prefix. byte_len: {}, bit_len: {}", byte_len, bit_len)))
-                }
-                let mut buff = [0; 16];
-                for i in 0..byte_len {
-                    buff[i] = self.read_8b()?
-                }
-                IpAddr::V6(Ipv6Addr::from(buff))
-            }
-        };
-        let prefix = match IpNet::new(addr, bit_len) {
-            Ok(p) => {p}
-            Err(_) => {
-                return Err(ParserError::ParseError(format!("Invalid network prefix length: {}", bit_len)))
-            }
-        };
-
-        Ok(NetworkPrefix::new(prefix, path_id))
-    }
-
-    pub fn read_address(&mut self, afi: &Afi) -> io::Result<IpAddr> {
+    fn read_address(&mut self, afi: &Afi) -> io::Result<IpAddr> {
         match afi {
             Afi::Ipv4 => {
                 match self.read_ipv4_address(){
@@ -182,38 +56,38 @@ impl  DataBytes <'_>{
         }
     }
 
-    pub fn read_ipv4_address(&mut self) -> Result<Ipv4Addr, ParserError> {
-        let addr = self.read_32b()?;
+    fn read_ipv4_address(&mut self) -> Result<Ipv4Addr, ParserError> {
+        let addr = self.read_u32::<BE>()?;
         Ok(Ipv4Addr::from(addr))
     }
 
-    pub fn read_ipv6_address(&mut self) -> Result<Ipv6Addr, ParserError> {
-        let buf = self.read_128b()?;
+    fn read_ipv6_address(&mut self) -> Result<Ipv6Addr, ParserError> {
+        let buf = self.read_u128::<BE>()?;
         Ok(Ipv6Addr::from(buf))
     }
 
-    pub fn read_ipv4_prefix(&mut self) -> Result<Ipv4Net, ParserError> {
+    fn read_ipv4_prefix(&mut self) -> Result<Ipv4Net, ParserError> {
         let addr = self.read_ipv4_address()?;
-        let mask = self.read_8b()?;
+        let mask = self.read_u8()?;
         match Ipv4Net::new(addr, mask) {
             Ok(n) => Ok(n),
             Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid prefix mask").into()),
         }
     }
 
-    pub fn read_ipv6_prefix(&mut self) -> Result<Ipv6Net, ParserError> {
+    fn read_ipv6_prefix(&mut self) -> Result<Ipv6Net, ParserError> {
         let addr = self.read_ipv6_address()?;
-        let mask = self.read_8b()?;
+        let mask = self.read_u8()?;
         match Ipv6Net::new(addr, mask) {
             Ok(n) => Ok(n),
             Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid prefix mask").into()),
         }
     }
 
-    pub fn read_asn(&mut self, as_length: &AsnLength) -> Result<Asn, ParserError> {
+    fn read_asn(&mut self, as_length: &AsnLength) -> Result<Asn, ParserError> {
         match as_length {
             AsnLength::Bits16 => {
-                let asn = self.read_16b()? as u32;
+                let asn = self.read_u16::<BE>()? as u32;
                 Ok(
                     Asn{
                         asn,
@@ -222,7 +96,7 @@ impl  DataBytes <'_>{
                 )
             },
             AsnLength::Bits32 => {
-                let asn = self.read_32b()? as u32;
+                let asn = self.read_u32::<BE>()? as u32;
                 Ok(
                     Asn{
                         asn,
@@ -233,21 +107,19 @@ impl  DataBytes <'_>{
         }
     }
 
-    pub fn read_asns(&mut self, as_length: &AsnLength, count: usize) -> Result<Vec<Asn>, ParserError> {
+    fn read_asns(&mut self, as_length: &AsnLength, count: usize) -> Result<Vec<Asn>, ParserError> {
         let mut path  = [0;255];
         Ok(
             match as_length {
                 AsnLength::Bits16 => {
                     for i in 0..count {
-                        path[i] = self.read_16b()? as u32;
-                        // path.push();
+                        path[i] = self.read_u16::<BE>()? as u32;
                     }
                     path[..count].iter().map(|asn| Asn{asn:*asn, len: *as_length}).collect::<Vec<Asn>>()
                 }
                 AsnLength::Bits32 => {
                     for i in 0..count {
-                        // path.push(Asn{asn: self.read_32b()? as i32, len: *as_length});
-                        path[i] = self.read_32b()? as u32;
+                        path[i] = self.read_u32::<BE>()? as u32;
                     }
                     path[..count].iter().map(|asn| Asn{asn:*asn, len: *as_length}).collect::<Vec<Asn>>()
                 }
@@ -255,8 +127,8 @@ impl  DataBytes <'_>{
         )
     }
 
-    pub fn read_afi(&mut self) -> Result<Afi, ParserError> {
-        let afi = self.read_16b()?;
+    fn read_afi(&mut self) -> Result<Afi, ParserError> {
+        let afi = self.read_u16::<BE>()?;
         match Afi::from_i16(afi as i16) {
             Some(afi) => Ok(afi),
             None => {
@@ -265,79 +137,133 @@ impl  DataBytes <'_>{
         }
     }
 
-    pub fn read_safi(&mut self) -> Result<Safi, ParserError> {
-        let safi = self.read_8b()?;
+    fn read_safi(&mut self) -> Result<Safi, ParserError> {
+        let safi = self.read_u8()?;
         match Safi::from_u8(safi) {
             Some(safi) => Ok(safi),
             None => Err(crate::error::ParserError::Unsupported(format!("Unknown SAFI type: {}", safi)))
         }
     }
 
-    pub fn parse_nlri_list(
-        &mut self,
-        add_path: bool,
-        afi: &Afi,
-        total_bytes: usize,
-    ) -> Result<Vec<NetworkPrefix>, ParserError> {
-        let pos_end = self.pos + total_bytes;
+    /// Read announced/withdrawn prefix.
+    ///
+    /// The length in bits is 1 byte, and then based on the IP version it reads different number of bytes.
+    /// If the `add_path` is true, it will also first read a 4-byte path id first; otherwise, a path-id of 0
+    /// is automatically set.
+    fn read_nlri_prefix(&mut self, afi: &Afi, add_path: bool) -> Result<NetworkPrefix, ParserError> {
 
-        let mut is_add_path = add_path;
-        let mut prefixes = vec![];
+        let path_id = if add_path {
+            self.read_u32::<BE>()?
+        } else {
+            0
+        };
 
-        let mut retry = false;
-        let mut guessed = false;
+        // Length in bits
+        let bit_len = self.read_u8()?;
 
-        let pos_save = self.pos;
+        // Convert to bytes
+        let byte_len: usize = (bit_len as usize + 7) / 8;
+        let addr:IpAddr = match afi {
+            Afi::Ipv4 => {
 
-        while self.pos < pos_end {
-            if !is_add_path && self.bytes[self.pos]==0 {
-                // it's likely that this is a add-path wrongfully wrapped in non-add-path msg
-                debug!("not add-path but with NLRI size to be 0, likely add-path msg in wrong msg type, treat as add-path now");
-                is_add_path = true;
-                guessed = true;
-            }
-            let prefix = match self.read_nlri_prefix(afi, is_add_path){
-                Ok(p) => {p}
-                Err(e) => {
-                    if guessed {
-                        retry = true;
-                        break;
-                    } else {
-                        return Err(e);
-                    }
+                // 4 bytes -- u32
+                if byte_len>4 {
+                    return Err(ParserError::ParseError(format!("Invalid byte length for IPv4 prefix. byte_len: {}, bit_len: {}", byte_len, bit_len)))
                 }
-            };
-            prefixes.push(prefix);
-        }
-
-        if retry {
-            prefixes.clear();
-            // try again without attempt to guess add-path
-            self.pos = pos_save;
-            while self.pos < pos_end {
-                let prefix = self.read_nlri_prefix(afi, add_path)?;
-                prefixes.push(prefix);
+                let mut buff = [0; 4];
+                for i in 0..byte_len {
+                    buff[i] = self.read_u8()?
+                }
+                IpAddr::V4(Ipv4Addr::from(buff))
             }
-        }
+            Afi::Ipv6 => {
+                // 16 bytes
+                if byte_len>16 {
+                    return Err(ParserError::ParseError(format!("Invalid byte length for IPv6 prefix. byte_len: {}, bit_len: {}", byte_len, bit_len)))
+                }
+                let mut buff = [0; 16];
+                for i in 0..byte_len {
+                    buff[i] = self.read_u8()?
+                }
+                IpAddr::V6(Ipv6Addr::from(buff))
+            }
+        };
+        let prefix = match IpNet::new(addr, bit_len) {
+            Ok(p) => {p}
+            Err(_) => {
+                return Err(ParserError::ParseError(format!("Invalid network prefix length: {}", bit_len)))
+            }
+        };
 
-        Ok(prefixes)
+        Ok(NetworkPrefix::new(prefix, path_id))
+    }
+
+    fn read_bytes_vec(&mut self, n_bytes: usize) -> Result<Vec<u8>, ParserError>{
+        // TODO: fix the checking
+        // if self.total - self.pos < n_bytes {
+        //     return Err(ParserError::IoNotEnoughBytes())
+        // }
+        let mut bytes = vec![];
+        for _ in 0..n_bytes {
+            bytes.push(self.read_u8()?);
+        }
+        Ok(bytes)
+    }
+
+    fn read_n_bytes_to_string(&mut self, n_bytes: usize) -> Result<String, ParserError>{
+        let buffer = self.read_bytes_vec(n_bytes)?;
+        Ok(buffer.into_iter().map(|x:u8| x as char).collect::<String>())
     }
 }
-// Allow reading IPs from Reads
-pub trait ReadUtils: io::Read {
-    #[inline]
-    fn read_32b(&mut self) -> io::Result<u32> {
-        let mut buf = [0; 4];
-        self.read_exact(&mut buf)?;
-        Ok(u32::from_be_bytes(buf))
+
+pub fn parse_nlri_list(
+    input: &mut Cursor<&[u8]>,
+    add_path: bool,
+    afi: &Afi,
+    total_bytes: u64,
+) -> Result<Vec<NetworkPrefix>, ParserError> {
+    let pos_end = input.position() + total_bytes;
+
+    let mut is_add_path = add_path;
+    let mut prefixes = vec![];
+
+    let mut retry = false;
+    let mut guessed = false;
+
+    let pos_save = input.position();
+
+    while input.position() < pos_end {
+        if !is_add_path && input.get_ref()[input.position() as usize]==0 {
+            // it's likely that this is a add-path wrongfully wrapped in non-add-path msg
+            debug!("not add-path but with NLRI size to be 0, likely add-path msg in wrong msg type, treat as add-path now");
+            is_add_path = true;
+            guessed = true;
+        }
+        let prefix = match input.read_nlri_prefix(afi, is_add_path){
+            Ok(p) => {p}
+            Err(e) => {
+                if guessed {
+                    retry = true;
+                    break;
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+        prefixes.push(prefix);
     }
 
-    #[inline]
-    fn read_16b(&mut self) -> io::Result<u16> {
-        let mut buf = [0; 2];
-        self.read_exact(&mut buf)?;
-        Ok(u16::from_be_bytes(buf))
+    if retry {
+        prefixes.clear();
+        // try again without attempt to guess add-path
+        input.seek(SeekFrom::Start(pos_save))?;
+        while input.position() < pos_end {
+            let prefix = input.read_nlri_prefix(afi, add_path)?;
+            prefixes.push(prefix);
+        }
     }
+
+    Ok(prefixes)
 }
 
 // All types that implement Read can now read prefixes


### PR DESCRIPTION
This is a major refactor that got rid of the custom `DataBytes` struct in favor of the standard `[u8]` and `std::io::Cursor<&[u8]>` for reading bytes. This allows downstreams to more easily work with existing toolchain and pass blob of bytes directly to parser functions if needed.