### PR TITLE
Make BgpkitParser Generic For Any Reader

### DIFF
--- a/bgpkit-parser-py/src/lib.rs
+++ b/bgpkit-parser-py/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Read;
 use bgpkit_parser::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -61,7 +62,7 @@ fn pybgpkit_parser(_py: Python, m: &PyModule) -> PyResult<()> {
     #[pyclass]
     #[pyo3(text_signature = "(url, filters, /)")]
     struct Parser {
-        elem_iter: ElemIterator,
+        elem_iter: ElemIterator<Box<dyn Send + Read>>,
     }
 
     #[pymethods]

--- a/bgpkit-parser/src/parser/iters.rs
+++ b/bgpkit-parser/src/parser/iters.rs
@@ -1,6 +1,7 @@
 /*!
 Provides parser iterator implementation.
 */
+use std::io::Read;
 use log::{error, warn};
 use bgp_models::mrt::{MrtMessage, MrtRecord, TableDumpV2Message};
 use crate::{BgpElem, Elementor};
@@ -9,20 +10,20 @@ use crate::parser::BgpkitParser;
 use crate::Filterable;
 
 /// Use [BgpElemIterator] as the default iterator to return [BgpElem]s instead of [MrtRecord]s.
-impl IntoIterator for BgpkitParser {
+impl<R: Read> IntoIterator for BgpkitParser<R> {
     type Item = BgpElem;
-    type IntoIter = ElemIterator;
+    type IntoIter = ElemIterator<R>;
 
     fn into_iter(self) -> Self::IntoIter {
         ElemIterator::new(self)
     }
 }
 
-impl BgpkitParser {
-    pub fn into_record_iter(self) -> RecordIterator {
+impl<R> BgpkitParser<R> {
+    pub fn into_record_iter(self) -> RecordIterator<R> {
         RecordIterator::new(self)
     }
-    pub fn into_elem_iter(self) -> ElemIterator {
+    pub fn into_elem_iter(self) -> ElemIterator<R> {
         ElemIterator::new(self)
     }
 }
@@ -32,21 +33,21 @@ MrtRecord Iterator
 **********/
 
 
-pub struct RecordIterator {
-    pub parser: BgpkitParser,
+pub struct RecordIterator<R> {
+    pub parser: BgpkitParser<R>,
     pub count: u64,
     elementor: Elementor,
 }
 
-impl RecordIterator {
-    fn new(parser: BgpkitParser) -> RecordIterator {
+impl<R> RecordIterator<R> {
+    fn new(parser: BgpkitParser<R>) -> Self {
         RecordIterator {
             parser , count: 0, elementor: Elementor::new()
         }
     }
 }
 
-impl Iterator for RecordIterator {
+impl<R: Read> Iterator for RecordIterator<R> {
     type Item = MrtRecord;
 
     fn next(&mut self) -> Option<MrtRecord> {
@@ -123,20 +124,20 @@ impl Iterator for RecordIterator {
 BgpElem Iterator
 **********/
 
-pub struct ElemIterator {
+pub struct ElemIterator<R> {
     cache_elems: Vec<BgpElem>,
-    record_iter: RecordIterator,
+    record_iter: RecordIterator<R>,
     elementor: Elementor,
     count: u64,
 }
 
-impl ElemIterator {
-    fn new(parser: BgpkitParser) -> ElemIterator {
+impl<R> ElemIterator<R> {
+    fn new(parser: BgpkitParser<R>) -> Self {
         ElemIterator { record_iter: RecordIterator::new(parser) , count: 0 , cache_elems: vec![], elementor: Elementor::new()}
     }
 }
 
-impl Iterator for ElemIterator {
+impl<R: Read> Iterator for ElemIterator<R> {
     type Item = BgpElem;
 
     fn next(&mut self) -> Option<BgpElem> {

--- a/bgpkit-parser/src/parser/mod.rs
+++ b/bgpkit-parser/src/parser/mod.rs
@@ -19,8 +19,8 @@ use bgp_models::prelude::MrtRecord;
 use oneio::get_reader;
 use crate::Filter;
 
-pub struct BgpkitParser {
-    reader: Box<dyn Read + Send>,
+pub struct BgpkitParser<R> {
+    reader: R,
     core_dump: bool,
     filters: Vec<Filter>,
     options: ParserOptions
@@ -37,9 +37,9 @@ impl Default for ParserOptions {
     }
 }
 
-impl BgpkitParser {
+impl BgpkitParser<Box<dyn Read + Send>> {
     /// Creating a new parser from a object that implements [Read] trait.
-    pub fn new(path: &str) -> Result<BgpkitParser, ParserErrorWithBytes>{
+    pub fn new(path: &str) -> Result<Self, ParserErrorWithBytes> {
         let reader = get_reader(path)?;
         Ok(
             BgpkitParser{
@@ -50,18 +50,27 @@ impl BgpkitParser {
             }
         )
     }
+}
 
+impl<R: Read> BgpkitParser<R> {
     /// Creating a new parser from a object that implements [Read] trait.
-    pub fn from_reader(reader: Box<dyn Read + Send>) -> Self {
-        BgpkitParser{
-            reader: Box::new(reader),
+    pub fn from_reader(reader: R) -> Self {
+        BgpkitParser {
+            reader,
             core_dump: false,
             filters: vec![],
             options: ParserOptions::default()
         }
     }
 
-    pub fn enable_core_dump(self) -> BgpkitParser {
+    /// This is used in for loop `for item in parser{}`
+    pub fn next_record(&mut self) -> Result<MrtRecord, ParserErrorWithBytes> {
+        parse_mrt_record(&mut self.reader)
+    }
+}
+
+impl<R> BgpkitParser<R> {
+    pub fn enable_core_dump(self) -> Self {
         BgpkitParser{
             reader: self.reader,
             core_dump: true,
@@ -70,7 +79,7 @@ impl BgpkitParser {
         }
     }
 
-    pub fn disable_warnings(self) -> BgpkitParser {
+    pub fn disable_warnings(self) -> Self {
         let mut options = self.options;
         options.show_warnings = false;
         BgpkitParser{
@@ -81,7 +90,7 @@ impl BgpkitParser {
         }
     }
 
-    pub fn add_filter(self, filter_type: &str, filter_value: &str) -> Result<BgpkitParser, ParserErrorWithBytes> {
+    pub fn add_filter(self, filter_type: &str, filter_value: &str) -> Result<Self, ParserErrorWithBytes> {
         let mut filters = self.filters;
         filters.push(Filter::new(filter_type, filter_value)?);
         Ok(
@@ -92,11 +101,6 @@ impl BgpkitParser {
                 options: self.options
             }
         )
-    }
-
-    /// This is used in for loop `for item in parser{}`
-    pub fn next_record(&mut self) -> Result<MrtRecord, ParserErrorWithBytes> {
-        parse_mrt_record(&mut self.reader)
     }
 }
 
@@ -110,9 +114,7 @@ mod tests {
         // bzip2 reader for compressed file
         let http_stream = ureq::get("http://archive.routeviews.org/route-views.ny/bgpdata/2023.02/UPDATES/updates.20230215.0630.bz2")
             .call().unwrap().into_reader();
-        let reader = Box::new(
-            bzip2::read::BzDecoder::new(http_stream)
-        );
+        let reader = bzip2::read::BzDecoder::new(http_stream);
         assert_eq!(12683, BgpkitParser::from_reader(reader).into_elem_iter().count());
 
         // remote reader for uncompressed updates file


### PR DESCRIPTION
These changes have the goal of allowing the `BgpkitParser` to use a generic reader including non-`'static` values as described in #74. The most important part of this is it allows the construction of `BgpkitParser` using mutable references to existing readers. This is helpful because it allows a `BgpkitParser` to be created without consuming ownership of the reader.

After making these changes, `cargo test` showed all tests passing on my machine.

On a somewhat related note, I have noticed a couple other areas where the performance could be improved with some simple changes. Are you open to additional pull requests?