### PR TITLE
add example to search for AS set messages

### DIFF
--- a/bgp-models/src/bgp/elem.rs
+++ b/bgp-models/src/bgp/elem.rs
@@ -30,6 +30,15 @@ impl Serialize for ElemType {
     }
 }
 
+impl ElemType {
+    pub fn is_announce(&self) -> bool {
+        match self {
+            ElemType::ANNOUNCE => true,
+            ElemType::WITHDRAW => false,
+        }
+    }
+}
+
 /// BgpElem represents per-prefix BGP element.
 ///
 /// The information is for per announced/withdrawn prefix.

--- a/bgpkit-parser/examples/find_as_set_messages.rs
+++ b/bgpkit-parser/examples/find_as_set_messages.rs
@@ -1,0 +1,49 @@
+use bgp_models::bgp::AsPathSegment;
+use bgpkit_broker::BgpkitBroker;
+use bgpkit_parser::BgpkitParser;
+use itertools::Itertools;
+use rayon::prelude::*;
+use std::collections::HashSet;
+
+fn main() {
+    let items = BgpkitBroker::new()
+        .data_type("rib")
+        .project("route-views")
+        .ts_start("2023-03-01T00:00:00Z")
+        .ts_end("2023-03-01T00:00:00Z")
+        .query()
+        .unwrap();
+
+    println!("start parsing {} ribs in parallel", items.len());
+    let res: Vec<(String, HashSet<u32>)> = items
+        .par_iter()
+        .flat_map(|item| {
+            let parser = BgpkitParser::new(item.url.as_str()).unwrap();
+            let collector = item.collector_id.clone();
+            let mut origins: HashSet<u32> = HashSet::new();
+            for elem in parser {
+                if !elem.elem_type.is_announce() {
+                    continue;
+                }
+                for seg in elem.as_path.as_ref().unwrap().segments() {
+                    match seg {
+                        AsPathSegment::AsSet(p) | AsPathSegment::ConfedSet(p) => {
+                            println!("{elem}");
+                            origins.insert(p.last().unwrap().asn);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            return Some((collector, origins));
+        })
+        .collect();
+
+    for (collector, origins) in res {
+        println!(
+            "{collector}\n{}",
+            origins.iter().map(|v| v.to_string()).join(", ")
+        );
+    }
+}

--- a/bgpkit-parser/examples/find_as_set_messages.rs
+++ b/bgpkit-parser/examples/find_as_set_messages.rs
@@ -1,7 +1,6 @@
 use bgp_models::bgp::AsPathSegment;
 use bgpkit_broker::BgpkitBroker;
 use bgpkit_parser::BgpkitParser;
-use itertools::Itertools;
 use rayon::prelude::*;
 use std::collections::HashSet;
 
@@ -15,35 +14,31 @@ fn main() {
         .unwrap();
 
     println!("start parsing {} ribs in parallel", items.len());
-    let res: Vec<(String, HashSet<u32>)> = items
-        .par_iter()
-        .flat_map(|item| {
-            let parser = BgpkitParser::new(item.url.as_str()).unwrap();
-            let collector = item.collector_id.clone();
-            let mut origins: HashSet<u32> = HashSet::new();
-            for elem in parser {
-                if !elem.elem_type.is_announce() {
-                    continue;
-                }
-                for seg in elem.as_path.as_ref().unwrap().segments() {
-                    match seg {
-                        AsPathSegment::AsSet(p) | AsPathSegment::ConfedSet(p) => {
-                            println!("{elem}");
-                            origins.insert(p.last().unwrap().asn);
-                        }
-                        _ => {}
+    items.par_iter().for_each(|item| {
+        let parser = BgpkitParser::new(item.url.as_str()).unwrap();
+        let collector = item.collector_id.clone();
+        let mut origins: HashSet<u32> = HashSet::new();
+        for elem in parser {
+            if !elem.elem_type.is_announce() {
+                continue;
+            }
+            for seg in elem.as_path.as_ref().unwrap().segments() {
+                match seg {
+                    AsPathSegment::AsSet(p) | AsPathSegment::ConfedSet(p) => {
+                        // println!("{elem}");
+                        origins.insert(p.last().unwrap().asn);
                     }
+                    _ => {}
                 }
             }
+        }
 
-            return Some((collector, origins));
-        })
-        .collect();
-
-    for (collector, origins) in res {
-        println!(
-            "{collector}\n{}",
-            origins.iter().map(|v| v.to_string()).join(", ")
-        );
-    }
+        if !origins.is_empty() {
+            println!(
+                "found {} origins with AS set from {} collector",
+                origins.len(),
+                collector.as_str()
+            );
+        }
+    });
 }


### PR DESCRIPTION
## Overview

Search for all RouteViews RIB dump files for one timestamp, and collect collectors and origins that announces AS Set messages.

## Run the example

```
cargo run --release --example find_as_set_messages
```

## Other changes

Add utility function `is_announce` to `ElemType` struct to avoid matching on the enum's sub types.