### PR TITLE
refactor to use Bytes struct for handling u8 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,9 @@ data received from their collectors. Below is an partial example of how we handl
 received from the Kafka stream. For full examples, check out the [examples folder on GitHub](https://github.com/bgpkit/bgpkit-parser/tree/main/examples).
 
 ```rust
-let bytes = m.value;
-let mut reader = Cursor::new(Vec::from(bytes));
-let header = parse_openbmp_header(&mut reader).unwrap();
-let bmp_msg = parse_bmp_msg(&mut reader);
+let mut bytes = Bytes::from(m.value.to_vec());
+let header = parse_openbmp_header(&mut bytes).unwrap();
+let bmp_msg = parse_bmp_msg(&mut bytes);
 match bmp_msg {
     Ok(msg) => {
         let timestamp = header.timestamp;

--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -28,6 +28,7 @@ serde={version="1.0.130", features=["derive"]}
 serde_json = "1.0.69" # RIS Live parsing
 hex="0.4.3" # bmp/openbmp parsing
 oneio = {version= "0.8.1", features=["lib_only"]}
+bytes = "1.4.0"
 
 env_logger = {version="0.10", optional=true}
 clap = {version= "4.0", features=["derive"], optional=true}

--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -21,7 +21,6 @@ ipnet = "2.7"
 enum-primitive-derive = "0.2"
 num-traits = "0.2"
 regex = "1"
-byteorder = "1"
 log="0.4"
 itertools = "0.10.1"
 serde={version="1.0.130", features=["derive"]}

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_01_origin.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_01_origin.rs
@@ -1,12 +1,11 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
+use bytes::Bytes;
 use num_traits::FromPrimitive;
-use std::io::Cursor;
 
-pub fn parse_origin(input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
-    let origin = input.read_8b()?;
-    match Origin::from_u8(origin) {
+pub fn parse_origin(mut input: Bytes) -> Result<AttributeValue, ParserError> {
+    match Origin::from_u8(input.read_u8()?) {
         Some(v) => Ok(AttributeValue::Origin(v)),
         None => Err(ParserError::UnknownAttr(
             "Failed to parse attribute type: origin".to_string(),
@@ -41,18 +40,18 @@ mod tests {
     fn test_parse_origin() {
         assert_eq!(
             AttributeValue::Origin(Origin::IGP),
-            parse_origin(&mut Cursor::new(&[0u8])).unwrap()
+            parse_origin(Bytes::from_static(&[0u8])).unwrap()
         );
         assert_eq!(
             AttributeValue::Origin(Origin::EGP),
-            parse_origin(&mut Cursor::new(&[1u8])).unwrap()
+            parse_origin(Bytes::from_static(&[1u8])).unwrap()
         );
         assert_eq!(
             AttributeValue::Origin(Origin::INCOMPLETE),
-            parse_origin(&mut Cursor::new(&[2u8])).unwrap()
+            parse_origin(Bytes::from_static(&[2u8])).unwrap()
         );
         assert!(matches!(
-            parse_origin(&mut Cursor::new(&[3u8])).unwrap_err(),
+            parse_origin(Bytes::from_static(&[3u8])).unwrap_err(),
             ParserError::UnknownAttr(_)
         ));
     }

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_04_med.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_04_med.rs
@@ -1,13 +1,10 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use std::io::Cursor;
+use bytes::Bytes;
 
-pub fn parse_med(input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
-    match input.read_32b() {
-        Ok(v) => Ok(AttributeValue::MultiExitDiscriminator(v)),
-        Err(err) => Err(ParserError::from(err)),
-    }
+pub fn parse_med(mut input: Bytes) -> Result<AttributeValue, ParserError> {
+    Ok(AttributeValue::MultiExitDiscriminator(input.read_u32()?))
 }
 
 #[cfg(test)]
@@ -17,7 +14,7 @@ mod tests {
     #[test]
     fn test_parse_med() {
         if let Ok(AttributeValue::MultiExitDiscriminator(123)) =
-            parse_med(&mut Cursor::new(&[0, 0, 0, 123]))
+            parse_med(Bytes::from(vec![0, 0, 0, 123]))
         {
         } else {
             panic!()

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_05_local_pref.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_05_local_pref.rs
@@ -1,13 +1,10 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use std::io::Cursor;
+use bytes::Bytes;
 
-pub fn parse_local_pref(input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
-    match input.read_32b() {
-        Ok(v) => Ok(AttributeValue::LocalPreference(v)),
-        Err(err) => Err(ParserError::from(err)),
-    }
+pub fn parse_local_pref(mut input: Bytes) -> Result<AttributeValue, ParserError> {
+    Ok(AttributeValue::LocalPreference(input.read_u32()?))
 }
 
 #[cfg(test)]
@@ -17,7 +14,7 @@ mod tests {
     #[test]
     fn test_parse_med() {
         if let Ok(AttributeValue::LocalPreference(123)) =
-            parse_local_pref(&mut Cursor::new(&[0, 0, 0, 123]))
+            parse_local_pref(Bytes::from(vec![0, 0, 0, 123]))
         {
         } else {
             panic!()

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_08_communities.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_08_communities.rs
@@ -1,29 +1,17 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use log::debug;
-use std::io::Cursor;
+use bytes::{Buf, Bytes};
 
-pub fn parse_regular_communities(
-    input: &mut Cursor<&[u8]>,
-    total_bytes: usize,
-) -> Result<AttributeValue, ParserError> {
+pub fn parse_regular_communities(mut input: Bytes) -> Result<AttributeValue, ParserError> {
     const COMMUNITY_NO_EXPORT: u32 = 0xFFFFFF01;
     const COMMUNITY_NO_ADVERTISE: u32 = 0xFFFFFF02;
     const COMMUNITY_NO_EXPORT_SUBCONFED: u32 = 0xFFFFFF03;
 
-    debug!(
-        "reading communities. cursor_pos: {}/{}; total to read: {}",
-        input.position(),
-        input.get_ref().len(),
-        total_bytes
-    );
-
     let mut communities = vec![];
-    let mut read = 0;
 
-    while read < total_bytes {
-        let community_val = input.read_32b()?;
+    while input.remaining() > 0 {
+        let community_val = input.read_u32()?;
         communities.push(match community_val {
             COMMUNITY_NO_EXPORT => Community::NoExport,
             COMMUNITY_NO_ADVERTISE => Community::NoAdvertise,
@@ -37,15 +25,8 @@ pub fn parse_regular_communities(
                 Community::Custom(asn, value)
             }
         });
-        read += 4;
     }
 
-    debug!(
-        "finished reading communities. cursor_pos: {}/{}; {:?}",
-        input.position(),
-        input.get_ref().len(),
-        &communities
-    );
     Ok(AttributeValue::Communities(communities))
 }
 
@@ -56,15 +37,14 @@ mod tests {
     /// Test parsing of communities values, as defined in RFC1997.
     #[test]
     fn test_parse_communities() {
-        if let Ok(AttributeValue::Communities(communities)) = parse_regular_communities(
-            &mut Cursor::new(&[
+        if let Ok(AttributeValue::Communities(communities)) =
+            parse_regular_communities(Bytes::from(vec![
                 0xFF, 0xFF, 0xFF, 0x01, // NoExport
                 0xFF, 0xFF, 0xFF, 0x02, // NoAdvertise
                 0xFF, 0xFF, 0xFF, 0x03, // NoExportSubConfed
                 0x00, 0x7B, 0x01, 0xC8, // Custom(123, 456)
-            ]),
-            16,
-        ) {
+            ]))
+        {
             assert_eq!(communities.len(), 4);
             assert_eq!(communities[0], Community::NoExport);
             assert_eq!(communities[1], Community::NoAdvertise);

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_09_originator.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_09_originator.rs
@@ -1,10 +1,10 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use std::io::Cursor;
+use bytes::Bytes;
 
 pub fn parse_originator_id(
-    input: &mut Cursor<&[u8]>,
+    mut input: Bytes,
     afi: &Option<Afi>,
 ) -> Result<AttributeValue, ParserError> {
     let afi = match afi {
@@ -25,7 +25,7 @@ mod tests {
     fn test_parse_originator_id() {
         let ipv4 = Ipv4Addr::from_str("10.0.0.1").unwrap();
         if let Ok(AttributeValue::OriginatorId(n)) =
-            parse_originator_id(&mut Cursor::new(&ipv4.octets()), &None)
+            parse_originator_id(Bytes::from(ipv4.octets().to_vec()), &None)
         {
             assert_eq!(n, ipv4);
         } else {
@@ -34,7 +34,7 @@ mod tests {
 
         let ipv6 = Ipv6Addr::from_str("fc::1").unwrap();
         if let Ok(AttributeValue::OriginatorId(n)) =
-            parse_originator_id(&mut Cursor::new(&ipv6.octets()), &Some(Afi::Ipv6))
+            parse_originator_id(Bytes::from(ipv6.octets().to_vec()), &Some(Afi::Ipv6))
         {
             assert_eq!(n, ipv6);
         } else {

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_32_large_communities.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_32_large_communities.rs
@@ -1,17 +1,14 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use std::io::Cursor;
+use bytes::{Buf, Bytes};
 
-pub fn parse_large_communities(
-    input: &mut Cursor<&[u8]>,
-    total_bytes: usize,
-) -> Result<AttributeValue, ParserError> {
+pub fn parse_large_communities(mut input: Bytes) -> Result<AttributeValue, ParserError> {
     let mut communities = Vec::new();
-    let pos_end = input.position() + total_bytes as u64;
-    while input.position() < pos_end {
-        let global_administrator = input.read_32b()?;
-        let local_data = [input.read_32b()?, input.read_32b()?];
+    while input.remaining() > 0 {
+        input.has_n_remaining(12)?; // 12 bytes for large community (3x 32 bits integers)
+        let global_administrator = input.get_u32();
+        let local_data = [input.get_u32(), input.get_u32()];
         communities.push(LargeCommunity::new(global_administrator, local_data));
     }
     Ok(AttributeValue::LargeCommunities(communities))
@@ -33,7 +30,7 @@ mod tests {
         ];
 
         if let Ok(AttributeValue::LargeCommunities(communities)) =
-            parse_large_communities(&mut Cursor::new(&data), data.len())
+            parse_large_communities(Bytes::from(data))
         {
             assert_eq!(communities.len(), 2);
             assert_eq!(communities[0].global_administrator, 1);

--- a/bgpkit-parser/src/parser/bgp/attributes/attr_35_otc.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_35_otc.rs
@@ -1,7 +1,7 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use std::io::Cursor;
+use bytes::Bytes;
 
 /// parse RFC9234 OnlyToCustomer attribute.
 ///
@@ -19,8 +19,8 @@ use std::io::Cursor;
 /// 1. If a route is to be advertised to a Customer, a Peer, or an RS-Client (when the sender is an RS), and the OTC Attribute is not present, then when advertising the route, an OTC Attribute MUST be added with a value equal to the AS number of the local AS.
 /// 2. If a route already contains the OTC Attribute, it MUST NOT be propagated to Providers, Peers, or RSes.
 /// ```
-pub fn parse_only_to_customer(input: &mut Cursor<&[u8]>) -> Result<AttributeValue, ParserError> {
-    let remote_asn = input.read_32b()?;
+pub fn parse_only_to_customer(mut input: Bytes) -> Result<AttributeValue, ParserError> {
+    let remote_asn = input.read_u32()?;
     Ok(AttributeValue::OnlyToCustomer(remote_asn))
 }
 
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn test_parse_otc() {
         if let Ok(AttributeValue::OnlyToCustomer(123)) =
-            parse_only_to_customer(&mut Cursor::new(&[0, 0, 0, 123]))
+            parse_only_to_customer(Bytes::from(vec![0, 0, 0, 123]))
         {
         } else {
             panic!("parsing error")

--- a/bgpkit-parser/src/parser/bmp/messages/route_monitoring.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/route_monitoring.rs
@@ -1,6 +1,7 @@
 use crate::models::*;
 use crate::parser::bgp::messages::parse_bgp_message;
 use crate::parser::bmp::error::ParserBmpError;
+use bytes::Bytes;
 
 #[derive(Debug)]
 pub struct RouteMonitoring {
@@ -8,7 +9,7 @@ pub struct RouteMonitoring {
 }
 
 pub fn parse_route_monitoring(
-    data: &[u8],
+    data: &mut Bytes,
     asn_len: &AsnLength,
 ) -> Result<RouteMonitoring, ParserBmpError> {
     // let bgp_update = parse_bgp_update_message(reader, false, afi, asn_len, total_len)?;

--- a/bgpkit-parser/src/parser/bmp/messages/stats_report.rs
+++ b/bgpkit-parser/src/parser/bmp/messages/stats_report.rs
@@ -1,6 +1,6 @@
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::ReadUtils;
-use std::io::Cursor;
+use bytes::Bytes;
 
 #[derive(Debug)]
 pub struct StatsReport {
@@ -21,15 +21,15 @@ pub enum StatsData {
     Gauge(u64),
 }
 
-pub fn parse_stats_report(reader: &mut Cursor<&[u8]>) -> Result<StatsReport, ParserBmpError> {
-    let stats_count = reader.read_32b()?;
+pub fn parse_stats_report(data: &mut Bytes) -> Result<StatsReport, ParserBmpError> {
+    let stats_count = data.read_u32()?;
     let mut counters = vec![];
     for _ in 0..stats_count {
-        let stat_type = reader.read_16b()?;
-        let stat_len = reader.read_16b()?;
+        let stat_type = data.read_u16()?;
+        let stat_len = data.read_u16()?;
         let stat_data = match stat_len {
-            4 => StatsData::Counter(reader.read_32b()?),
-            8 => StatsData::Gauge(reader.read_64b()?),
+            4 => StatsData::Counter(data.read_u32()?),
+            8 => StatsData::Gauge(data.read_u64()?),
             _ => return Err(ParserBmpError::CorruptedBmpMessage),
         };
         counters.push(StatCounter {

--- a/bgpkit-parser/src/parser/bmp/mod.rs
+++ b/bgpkit-parser/src/parser/bmp/mod.rs
@@ -4,7 +4,7 @@ Provides parsing for BMP and OpenBMP binary-formatted messages.
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::bmp::messages::*;
 pub use crate::parser::bmp::openbmp::parse_openbmp_header;
-use std::io::Cursor;
+use bytes::Bytes;
 
 pub mod error;
 pub mod messages;
@@ -13,15 +13,14 @@ pub mod openbmp;
 /// Parse OpenBMP `raw_bmp` message.
 ///
 /// An OpenBMP `raw_bmp` message contains a [OpenBmpHeader] and a [BmpMessage].
-pub fn parse_openbmp_msg(data: &[u8]) -> Result<BmpMessage, ParserBmpError> {
-    let mut reader = Cursor::new(data);
-    let _header = parse_openbmp_header(&mut reader)?;
-    parse_bmp_msg(&mut reader)
+pub fn parse_openbmp_msg(mut data: Bytes) -> Result<BmpMessage, ParserBmpError> {
+    let _header = parse_openbmp_header(&mut data)?;
+    parse_bmp_msg(&mut data)
 }
 
 /// Parse a BMP message.
-pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmpError> {
-    let common_header = parse_bmp_common_header(reader)?;
+pub fn parse_bmp_msg(data: &mut Bytes) -> Result<BmpMessage, ParserBmpError> {
+    let common_header = parse_bmp_common_header(data)?;
 
     // let mut buffer ;
     // if total_len>common_header.msg_len {
@@ -38,10 +37,8 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
 
     match &common_header.msg_type {
         BmpMsgType::RouteMonitoring => {
-            let per_peer_header = parse_per_peer_header(reader)?;
-            let pos_start = reader.position() as usize;
-            let data_bytes = &reader.get_ref()[pos_start..];
-            let msg = parse_route_monitoring(data_bytes, &per_peer_header.asn_len)?;
+            let per_peer_header = parse_per_peer_header(data)?;
+            let msg = parse_route_monitoring(data, &per_peer_header.asn_len)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -49,8 +46,8 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::RouteMirroringMessage => {
-            let per_peer_header = parse_per_peer_header(reader)?;
-            let msg = parse_route_mirroring(reader, &per_peer_header.asn_len)?;
+            let per_peer_header = parse_per_peer_header(data)?;
+            let msg = parse_route_mirroring(data, &per_peer_header.asn_len)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -58,8 +55,8 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::StatisticsReport => {
-            let per_peer_header = parse_per_peer_header(reader)?;
-            let msg = parse_stats_report(reader)?;
+            let per_peer_header = parse_per_peer_header(data)?;
+            let msg = parse_stats_report(data)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -67,8 +64,8 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::PeerDownNotification => {
-            let per_peer_header = parse_per_peer_header(reader)?;
-            let msg = parse_peer_down_notification(reader)?;
+            let per_peer_header = parse_per_peer_header(data)?;
+            let msg = parse_peer_down_notification(data)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -76,8 +73,8 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::PeerUpNotification => {
-            let per_peer_header = parse_per_peer_header(reader)?;
-            let msg = parse_peer_up_notification(reader, &per_peer_header.afi)?;
+            let per_peer_header = parse_per_peer_header(data)?;
+            let msg = parse_peer_up_notification(data, &per_peer_header.afi)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -85,7 +82,7 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::InitiationMessage => {
-            let msg = parse_initiation_message(reader)?;
+            let msg = parse_initiation_message(data)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: None,
@@ -93,7 +90,7 @@ pub fn parse_bmp_msg(reader: &mut Cursor<&[u8]>) -> Result<BmpMessage, ParserBmp
             })
         }
         BmpMsgType::TerminationMessage => {
-            let msg = parse_termination_message(reader)?;
+            let msg = parse_termination_message(data)?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: None,
@@ -113,17 +110,17 @@ mod tests {
     fn test_peer_down_notification() {
         let input = "4f424d500107006400000033800c6184b9c2000c602cbf4f072f3ae149d23486024bc3dadfc4000a69732d63632d626d7031c677060bdd020a9e92be000200de2e3180df3369000000000000000000000000000c726f7574652d76696577733500000001030000003302000000000000000000000000000000000000000000003fda060e00000da30000000061523c36000c0e1c0200000a";
         let decoded = hex::decode(input).unwrap();
-        let mut reader = Cursor::new(decoded.as_slice());
-        let _header = parse_openbmp_header(&mut reader).unwrap();
-        let _msg = parse_bmp_msg(&mut reader).unwrap();
+        let mut data = Bytes::from(decoded);
+        let _header = parse_openbmp_header(&mut data).unwrap();
+        let _msg = parse_bmp_msg(&mut data).unwrap();
     }
 
     #[test]
     fn test_route_monitoring() {
         let input = "4f424d500107005c000000b0800c618881530002f643fef880938d19e9d632c815d1e95a87e1000a69732d61682d626d7031eb4de4e596b282c6a995b067df4abc8cc342f19200000000000000000000000000046c696e780000000103000000b00000c00000000000000000200107f800040000000000001aae000400001aae5474800e02dddf5d00000000ffffffffffffffffffffffffffffffff00800200000069400101005002001602050000192f00001aae0000232a000328eb00032caec008181aae42681aae44581aae464f1aae59d91aae866543000000900e002c00020120200107f800040000000000001aae0004fe8000000000000082711ffffe7f29f100302a0fca8000010a";
         let decoded = hex::decode(input).unwrap();
-        let mut reader = Cursor::new(decoded.as_slice());
-        let _header = parse_openbmp_header(&mut reader).unwrap();
-        let _msg = parse_bmp_msg(&mut reader).unwrap();
+        let mut data = Bytes::from(decoded);
+        let _header = parse_openbmp_header(&mut data).unwrap();
+        let _msg = parse_bmp_msg(&mut data).unwrap();
     }
 }

--- a/bgpkit-parser/src/parser/bmp/openbmp.rs
+++ b/bgpkit-parser/src/parser/bmp/openbmp.rs
@@ -1,6 +1,6 @@
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::ReadUtils;
-use std::io::{Cursor, Seek, SeekFrom};
+use bytes::{Buf, Bytes};
 use std::net::IpAddr;
 
 ///
@@ -57,68 +57,68 @@ pub struct OpenBmpHeader {
     pub router_group: Option<String>,
 }
 
-pub fn parse_openbmp_header(reader: &mut Cursor<&[u8]>) -> Result<OpenBmpHeader, ParserBmpError> {
+pub fn parse_openbmp_header(data: &mut Bytes) -> Result<OpenBmpHeader, ParserBmpError> {
     // read magic number
-    let magic_number = reader.read_n_bytes_to_string(4)?;
+    let magic_number = data.read_n_bytes_to_string(4)?;
     if magic_number != "OBMP" {
         return Err(ParserBmpError::InvalidOpenBmpHeader);
     }
 
     // read version numbers
-    let version_major = reader.read_8b()?;
-    let version_minor = reader.read_8b()?;
+    let version_major = data.read_u8()?;
+    let version_minor = data.read_u8()?;
     if (version_major, version_minor) != (1, 7) {
         return Err(ParserBmpError::InvalidOpenBmpHeader);
     }
 
     // read msg lengths
-    let header_len = reader.read_16b()?;
-    let msg_len = reader.read_32b()?;
+    let header_len = data.read_u16()?;
+    let msg_len = data.read_u32()?;
 
     // read flags
-    let flags = reader.read_8b()?;
+    let flags = data.read_u8()?;
     let (is_router_msg, is_router_ipv6) = (flags & 0x80 != 0, flags & 0x40 != 0);
     if !is_router_msg {
         return Err(ParserBmpError::UnsupportedOpenBmpMessage);
     }
 
     // read object type
-    let object_type = reader.read_8b()?;
+    let object_type = data.read_u8()?;
     if object_type != 12 {
         return Err(ParserBmpError::UnsupportedOpenBmpMessage);
     }
 
     // read_timestamp
-    let t_sec = reader.read_32b()?;
-    let t_usec = reader.read_32b()?;
+    let t_sec = data.read_u32()?;
+    let t_usec = data.read_u32()?;
     let timestamp = t_sec as f64 + (t_usec as f64) / 1_000_000.0;
 
     // read admin-id
-    reader.seek(SeekFrom::Current(16))?;
-    let mut name_len = reader.read_16b()?;
+    data.advance(16);
+    let mut name_len = data.read_u16()?;
     if name_len > 255 {
         name_len = 255;
     }
-    let admin_id = reader.read_n_bytes_to_string(name_len as usize)?;
+    let admin_id = data.read_n_bytes_to_string(name_len as usize)?;
 
     // read router IP
-    reader.seek(SeekFrom::Current(16))?;
+    data.advance(16);
     let ip: IpAddr = if is_router_ipv6 {
-        reader.read_ipv6_address()?.into()
+        data.read_ipv6_address()?.into()
     } else {
-        let ip = reader.read_ipv4_address()?;
-        reader.seek(SeekFrom::Current(12))?;
+        let ip = data.read_ipv4_address()?;
+        data.advance(12);
         ip.into()
     };
 
     // read router group
-    let group = match reader.read_16b()? {
+    let group = match data.read_u16()? {
         0 => "".to_string(),
-        n => reader.read_n_bytes_to_string(n as usize)?,
+        n => data.read_n_bytes_to_string(n as usize)?,
     };
 
     // read msg count
-    let row_count = reader.read_32b()?;
+    let row_count = data.read_u32()?;
     if row_count != 1 {
         return Err(ParserBmpError::InvalidOpenBmpHeader);
     }
@@ -144,7 +144,7 @@ mod tests {
     fn test_open_bmp_header() {
         let input = "4f424d500107006400000033800c6184b9c2000c602cbf4f072f3ae149d23486024bc3dadfc4000a69732d63632d626d7031c677060bdd020a9e92be000200de2e3180df3369000000000000000000000000000c726f7574652d76696577733500000001030000003302000000000000000000000000000000000000000000003fda060e00000da30000000061523c36000c0e1c0200000a";
         let decoded = hex::decode(input).unwrap();
-        let mut reader = Cursor::new(decoded.as_slice());
-        let _header = parse_openbmp_header(&mut reader).unwrap();
+        let mut data = Bytes::from(decoded);
+        let _header = parse_openbmp_header(&mut data).unwrap();
     }
 }

--- a/bgpkit-parser/src/parser/mrt/mrt_record.rs
+++ b/bgpkit-parser/src/parser/mrt/mrt_record.rs
@@ -2,11 +2,10 @@ use crate::error::ParserError;
 use crate::models::*;
 use crate::parser::{
     parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message, ParserErrorWithBytes,
-    ReadUtils,
 };
-use byteorder::{ReadBytesExt, BE};
-use num_traits::FromPrimitive;
-use std::io::{ErrorKind, Read};
+use bytes::{Buf, Bytes, BytesMut};
+use num_traits::{FromPrimitive, ToPrimitive};
+use std::io::Read;
 
 /// MRT common header
 ///
@@ -43,30 +42,24 @@ use std::io::{ErrorKind, Read};
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 pub fn parse_common_header<T: Read>(input: &mut T) -> Result<CommonHeader, ParserError> {
-    let timestamp = match input.read_32b() {
-        Ok(t) => t,
-        Err(e) => {
-            return match e.kind() {
-                ErrorKind::UnexpectedEof => Err(ParserError::EofExpected),
-                _ => Err(ParserError::from(e)),
-            }
-        }
-    };
+    let mut raw_bytes = [0u8; 12];
+    input.read_exact(&mut raw_bytes)?;
+    let mut data = BytesMut::from(&raw_bytes[..]);
 
-    let entry_type_raw = input.read_u16::<BE>()?;
-    let entry_type = match EntryType::from_u16(entry_type_raw) {
-        Some(t) => Ok(t),
-        None => Err(ParserError::ParseError(format!(
-            "Failed to parse entry type: {}",
-            entry_type_raw
-        ))),
-    }?;
-    let entry_subtype = input.read_u16::<BE>()?;
-    let mut length = input.read_32b()?;
+    let timestamp = data.get_u32();
+    let entry_type_raw = data.get_u16();
+    let entry_type = EntryType::from_u16(entry_type_raw).ok_or_else(|| {
+        ParserError::ParseError(format!("Failed to parse entry type: {}", entry_type_raw))
+    })?;
+    let entry_subtype = data.get_u16();
+    let mut length = data.get_u32();
+
     let microsecond_timestamp = match &entry_type {
         EntryType::BGP4MP_ET => {
             length -= 4;
-            Some(input.read_32b()?)
+            let mut raw_bytes: [u8; 4] = [0; 4];
+            input.read_exact(&mut raw_bytes)?;
+            Some(BytesMut::from(&raw_bytes[..]).get_u32())
         }
         _ => None,
     };
@@ -85,18 +78,24 @@ pub fn parse_mrt_record(input: &mut impl Read) -> Result<MrtRecord, ParserErrorW
     let common_header = match parse_common_header(input) {
         Ok(v) => v,
         Err(e) => {
+            if let ParserError::EofError(e) = &e {
+                if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                    return Err(ParserErrorWithBytes::from(ParserError::EofExpected));
+                }
+            }
             return Err(ParserErrorWithBytes {
                 error: e,
                 bytes: None,
-            })
+            });
         }
     };
 
     // read the whole message bytes to buffer
-    let mut buffer = Vec::with_capacity(common_header.length as usize);
+    let mut buffer = BytesMut::with_capacity(common_header.length as usize);
+    buffer.resize(common_header.length as usize, 0);
     match input
         .take(common_header.length as u64)
-        .read_to_end(&mut buffer)
+        .read_exact(&mut buffer)
     {
         Ok(_) => {}
         Err(e) => {
@@ -107,30 +106,56 @@ pub fn parse_mrt_record(input: &mut impl Read) -> Result<MrtRecord, ParserErrorW
         }
     }
 
-    match parse_raw_bytes(&common_header, buffer.as_slice()) {
+    match parse_mrt_body(
+        common_header.entry_type.to_u16().unwrap(),
+        common_header.entry_subtype,
+        buffer.freeze(), // freeze the BytesMute to Bytes
+    ) {
         Ok(message) => Ok(MrtRecord {
             common_header,
             message,
         }),
         Err(e) => {
-            let mut total_bytes = vec![];
-            if common_header.write_header(&mut total_bytes).is_err() {
-                unreachable!("Vec<u8> will never produce errors when used as a std::io::Write")
-            }
+            // TODO: find more efficient way to preserve the bytes during error
+            // let mut total_bytes = vec![];
+            // if common_header.write_header(&mut total_bytes).is_err() {
+            //     unreachable!("Vec<u8> will never produce errors when used as a std::io::Write")
+            // }
 
-            total_bytes.extend(buffer);
+            // total_bytes.extend(buffer);
+            // Err(ParserErrorWithBytes {
+            //     error: e,
+            //     bytes: Some(total_bytes),
+            // })
             Err(ParserErrorWithBytes {
                 error: e,
-                bytes: Some(total_bytes),
+                bytes: None,
             })
         }
     }
 }
 
-fn parse_raw_bytes(common_header: &CommonHeader, data: &[u8]) -> Result<MrtMessage, ParserError> {
-    let message: MrtMessage = match &common_header.entry_type {
+/// Parse MRT message body with given entry type and subtype.
+///
+/// The entry type and subtype are parsed from the common header. The message body is parsed
+/// according to the entry type and subtype. The message body is the remaining bytes after the
+/// common header. The length of the message body is also parsed from the common header.
+fn parse_mrt_body(
+    entry_type: u16,
+    entry_subtype: u16,
+    data: Bytes,
+) -> Result<MrtMessage, ParserError> {
+    let etype = match EntryType::from_u16(entry_type) {
+        Some(t) => Ok(t),
+        None => Err(ParserError::ParseError(format!(
+            "Failed to parse entry type: {}",
+            entry_type
+        ))),
+    }?;
+
+    let message: MrtMessage = match &etype {
         EntryType::TABLE_DUMP => {
-            let msg = parse_table_dump_message(common_header.entry_subtype, data);
+            let msg = parse_table_dump_message(entry_subtype, data);
             match msg {
                 Ok(msg) => MrtMessage::TableDumpMessage(msg),
                 Err(e) => {
@@ -139,7 +164,7 @@ fn parse_raw_bytes(common_header: &CommonHeader, data: &[u8]) -> Result<MrtMessa
             }
         }
         EntryType::TABLE_DUMP_V2 => {
-            let msg = parse_table_dump_v2_message(common_header.entry_subtype, data);
+            let msg = parse_table_dump_v2_message(entry_subtype, data);
             match msg {
                 Ok(msg) => MrtMessage::TableDumpV2Message(msg),
                 Err(e) => {
@@ -148,7 +173,7 @@ fn parse_raw_bytes(common_header: &CommonHeader, data: &[u8]) -> Result<MrtMessa
             }
         }
         EntryType::BGP4MP | EntryType::BGP4MP_ET => {
-            let msg = parse_bgp4mp(common_header.entry_subtype, data);
+            let msg = parse_bgp4mp(entry_subtype, data);
             match msg {
                 Ok(msg) => MrtMessage::Bgp4Mp(msg),
                 Err(e) => {


### PR DESCRIPTION
Using `bytes` crate's `Bytes` and `ByteMut` allows more generic byte array operations.