### PR TITLE
fix cache file duplicate file name issue

### DIFF
--- a/bgpkit-parser/examples/cache_reading.rs
+++ b/bgpkit-parser/examples/cache_reading.rs
@@ -1,0 +1,24 @@
+use bgpkit_broker::BgpkitBroker;
+use bgpkit_parser::{BgpElem, BgpkitParser};
+
+/// This example shows how use BGPKIT Broker to retrieve a number of data file pointers that matches
+/// the time range criteria, and then parse the data files for each one.
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let broker = BgpkitBroker::new()
+        .ts_start("2014-04-01T00:00:01Z")
+        .ts_end("2014-04-01T00:04:59Z")
+        .project("riperis")
+        .data_type("update");
+
+    for item in broker.query().unwrap() {
+        let parser =
+            BgpkitParser::new_cached(item.url.as_str(), "/tmp/bgpkit-cache-example/").unwrap();
+        // dbg!(&item);
+        // println!("{}", item.url);
+        // iterating through the parser. the iterator returns `BgpElem` one at a time.
+        let elems = parser.into_elem_iter().collect::<Vec<BgpElem>>();
+        log::info!("{} {} {}", item.collector_id, item.url, elems.len());
+    }
+}

--- a/bgpkit-parser/examples/cache_reading.rs
+++ b/bgpkit-parser/examples/cache_reading.rs
@@ -1,8 +1,7 @@
 use bgpkit_broker::BgpkitBroker;
 use bgpkit_parser::{BgpElem, BgpkitParser};
 
-/// This example shows how use BGPKIT Broker to retrieve a number of data file pointers that matches
-/// the time range criteria, and then parse the data files for each one.
+/// This example shows how use parser's cache feature to read data files from the local disk.
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -15,8 +14,6 @@ fn main() {
     for item in broker.query().unwrap() {
         let parser =
             BgpkitParser::new_cached(item.url.as_str(), "/tmp/bgpkit-cache-example/").unwrap();
-        // dbg!(&item);
-        // println!("{}", item.url);
         // iterating through the parser. the iterator returns `BgpElem` one at a time.
         let elems = parser.into_elem_iter().collect::<Vec<BgpElem>>();
         log::info!("{} {} {}", item.collector_id, item.url, elems.len());

--- a/bgpkit-parser/src/parser/mod.rs
+++ b/bgpkit-parser/src/parser/mod.rs
@@ -58,7 +58,10 @@ impl BgpkitParser<Box<dyn Read + Send>> {
     /// will be cached as `cache-682cb1eb-rib.20230326.0600.bz2` in the cache directory.
     pub fn new_cached(path: &str, cache_dir: &str) -> Result<Self, ParserErrorWithBytes> {
         let file_name = path.rsplit('/').next().unwrap().to_string();
-        let new_file_name = format!("cache-{}-{}", crc32(file_name.as_str()), file_name);
+        let new_file_name = format!(
+            "cache-{}",
+            add_suffix_to_filename(file_name.as_str(), crc32(path).as_str())
+        );
         let reader = get_cache_reader(path, cache_dir, Some(new_file_name), false)?;
         Ok(BgpkitParser {
             reader,
@@ -66,6 +69,19 @@ impl BgpkitParser<Box<dyn Read + Send>> {
             filters: vec![],
             options: ParserOptions::default(),
         })
+    }
+}
+
+fn add_suffix_to_filename(filename: &str, suffix: &str) -> String {
+    let mut parts: Vec<&str> = filename.split('.').collect(); // Split filename by dots
+    if parts.len() > 1 {
+        let last_part = parts.pop().unwrap(); // Remove the last part (suffix) from the parts vector
+        let new_last_part = format!("{}.{}", suffix, last_part); // Add the suffix to the last part
+        parts.push(&new_last_part); // Add the updated last part back to the parts vector
+        parts.join(".") // Join the parts back into a filename string with dots
+    } else {
+        // If the filename does not have any dots, simply append the suffix to the end
+        format!("{}.{}", filename, suffix)
     }
 }
 


### PR DESCRIPTION
Original issue described in https://github.com/bgpkit/bgpkit-parser/issues/96#issuecomment-1496476670

The problem was that the CRC hash was generated based on the file name, not the full URL path, which loses the collector information that makes them different. As a result, all collectors MRT file of the same time will result in the same hash.

While fixing this issue, I also took the suggestion from @ mikolaj-kow to change the cache file naming convention to `cache-FILENAME-HASH.gz/bz2`. This makes the cache files more easier to organize.

This pull request also added an example to demonstrate the cache file reading feature.