### PR TITLE
Fix aggregator parsing

### DIFF
--- a/bgpkit-parser/src/parser/bgp/attributes/attr_07_18_aggregator.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/attr_07_18_aggregator.rs
@@ -1,40 +1,64 @@
 use crate::models::*;
 use crate::parser::ReadUtils;
 use crate::ParserError;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
+use log::warn;
 
+/// Parse aggregator attribute.
+///
+/// https://www.rfc-editor.org/rfc/rfc4271.html#section-5.1.7
+///
+/// ```text
+///    AGGREGATOR is an optional transitive attribute, which MAY be included
+///    in updates that are formed by aggregation (see Section 9.2.2.2).  A
+///    BGP speaker that performs route aggregation MAY add the AGGREGATOR
+///    attribute, which SHALL contain its own AS number and IP address.  The
+///    IP address SHOULD be the same as the BGP Identifier of the speaker.`
+/// ```
 pub fn parse_aggregator(
     mut input: Bytes,
     asn_len: &AsnLength,
-    afi: &Option<Afi>,
 ) -> Result<AttributeValue, ParserError> {
-    let asn = input.read_asn(asn_len)?;
-    let afi = match afi {
-        None => &Afi::Ipv4,
-        Some(a) => a,
+    let asn_len_found = match input.remaining() {
+        8 => AsnLength::Bits32,
+        6 => AsnLength::Bits16,
+        _ => {
+            return Err(ParserError::ParseError(format!(
+                "Aggregator attribute length is invalid: found {}, should 6 or 8",
+                input.remaining()
+            )))
+        }
     };
-    let addr = input.read_address(afi)?;
-    Ok(AttributeValue::Aggregator(asn, addr))
+    if asn_len_found != *asn_len {
+        warn!(
+            "Aggregator attribute with ASN length set to {:?} but found {:?}",
+            asn_len, asn_len_found
+        );
+    }
+    let asn = input.read_asn(&asn_len_found)?;
+
+    // the BGP identifier is always 4 bytes or IPv4 address
+    let identifier = input.read_address(&Afi::Ipv4)?;
+    Ok(AttributeValue::Aggregator(asn, identifier))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::net::Ipv4Addr;
     use std::str::FromStr;
 
     #[test]
     fn test_parse_aggregator() {
-        let ipv4 = Ipv4Addr::from_str("10.0.0.1").unwrap();
+        let identifier = Ipv4Addr::from_str("10.0.0.1").unwrap();
         let mut data = vec![];
         data.extend([1u8, 2]);
-        data.extend(ipv4.octets());
+        data.extend(identifier.octets());
         let bytes = Bytes::from(data);
 
-        if let Ok(AttributeValue::Aggregator(asn, n)) =
-            parse_aggregator(bytes.clone(), &AsnLength::Bits16, &None)
+        if let Ok(AttributeValue::Aggregator(asn, n)) = parse_aggregator(bytes, &AsnLength::Bits16)
         {
-            assert_eq!(n, ipv4);
+            assert_eq!(n, identifier);
             assert_eq!(
                 asn,
                 Asn {
@@ -46,31 +70,14 @@ mod tests {
             panic!()
         }
 
-        if let Ok(AttributeValue::Aggregator(asn, n)) =
-            parse_aggregator(bytes.clone(), &AsnLength::Bits16, &Some(Afi::Ipv4))
-        {
-            assert_eq!(n, ipv4);
-            assert_eq!(
-                asn,
-                Asn {
-                    asn: 258,
-                    len: AsnLength::Bits16
-                }
-            )
-        } else {
-            panic!()
-        }
-
-        let ipv6 = Ipv6Addr::from_str("fc00::1").unwrap();
         let mut data = vec![];
         data.extend([0u8, 0, 1, 2]);
-        data.extend(ipv6.octets());
+        data.extend(identifier.octets());
         let bytes = Bytes::from(data);
 
-        if let Ok(AttributeValue::Aggregator(asn, n)) =
-            parse_aggregator(bytes, &AsnLength::Bits32, &Some(Afi::Ipv6))
+        if let Ok(AttributeValue::Aggregator(asn, n)) = parse_aggregator(bytes, &AsnLength::Bits32)
         {
-            assert_eq!(n, ipv6);
+            assert_eq!(n, identifier);
             assert_eq!(
                 asn,
                 Asn {

--- a/bgpkit-parser/src/parser/bgp/attributes/mod.rs
+++ b/bgpkit-parser/src/parser/bgp/attributes/mod.rs
@@ -129,7 +129,7 @@ impl AttributeParser {
                 AttrType::ATOMIC_AGGREGATE => {
                     Ok(AttributeValue::AtomicAggregate(AtomicAggregate::AG))
                 }
-                AttrType::AGGREGATOR => parse_aggregator(attr_data, asn_len, &afi),
+                AttrType::AGGREGATOR => parse_aggregator(attr_data, asn_len),
                 AttrType::ORIGINATOR_ID => parse_originator_id(attr_data, &afi),
                 AttrType::CLUSTER_LIST => parse_clusters(attr_data, &afi),
                 AttrType::MP_REACHABLE_NLRI => parse_nlri(
@@ -149,7 +149,7 @@ impl AttributeParser {
                     self.additional_paths,
                 ),
                 AttrType::AS4_PATH => parse_as_path(attr_data, &AsnLength::Bits32),
-                AttrType::AS4_AGGREGATOR => parse_aggregator(attr_data, &AsnLength::Bits32, &afi),
+                AttrType::AS4_AGGREGATOR => parse_aggregator(attr_data, &AsnLength::Bits32),
 
                 // communities
                 AttrType::COMMUNITIES => parse_regular_communities(attr_data),


### PR DESCRIPTION
## Summary
Fixes issue #75 by ensuring that the BGP aggregator's identifier is always a 4-byte IPv4 address.

## Details
Previously, there was an issue with parsing IPv6 addresses as aggregator identifiers in IPv6 RIB dumps, which caused warnings to be displayed. This issue only affects the parsing of the aggregator attribute itself and should not cause any other inaccuracies in parsing results for other path attributes. 

With this fix, the BGP aggregator's identifier will consistently be a 4-byte IPv4 address, resolving the issue completely.

## Relevant RFCs

- RFC4271: https://www.rfc-editor.org/rfc/rfc4271.html#section-5.1.7
- RFC4893: https://www.rfc-editor.org/rfc/rfc4893
- RFC6793: https://www.rfc-editor.org/rfc/rfc6793.html

> AGGREGATOR is an optional transitive attribute, which MAY be included in updates that are formed by aggregation (see Section 9.2.2.2). A BGP speaker that performs route aggregation MAY add the AGGREGATOR attribute, which SHALL contain its own AS number and IP address. The IP address SHOULD be the same as the BGP Identifier of the speaker.

