### PR TITLE
Properly handle remote file opening errors

### DIFF
--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -26,7 +26,7 @@ ipnet = "2.7"
 itertools = "0.10.1"
 log="0.4"
 num-traits = "0.2"
-oneio = {version= "0.8.1", features=["lib_only"]}
+oneio = {version= "0.9.0", features=["lib_only"]}
 regex = "1"
 serde={version="1.0.130", features=["derive"]}
 serde_json = "1.0.69" # RIS Live parsing

--- a/bgpkit-parser/src/bin/main.rs
+++ b/bgpkit-parser/src/bin/main.rs
@@ -88,10 +88,18 @@ fn main() {
 
     env_logger::init();
 
-    let mut parser = match opts.cache_dir {
-        None => BgpkitParser::new(opts.file_path.to_str().unwrap()).unwrap(),
-        Some(c) => {
-            BgpkitParser::new_cached(opts.file_path.to_str().unwrap(), c.to_str().unwrap()).unwrap()
+    let file_path = opts.file_path.to_str().unwrap();
+
+    let mut parser = match {
+        match opts.cache_dir {
+            None => BgpkitParser::new(file_path),
+            Some(c) => BgpkitParser::new_cached(file_path, c.to_str().unwrap()),
+        }
+    } {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
         }
     };
 


### PR DESCRIPTION
Updated the file handle dependency library `oneio` to version `0.9.0` (see https://github.com/bgpkit/oneio/releases/tag/v0.9.0). Update the CLI to return error code `1` when receiving remote file errors like 404.

```
bgpkit-parser 'https://data.ris.ripe.net/rrc00/2023.04/updates.20230401.0231.gz'`
Error: remote IO error: HTTP status client error (404 Not Found) for url (https://data.ris.ripe.net/rrc00/2023.04/updates.20230401.0231.gz)

echo $?
1
```

Related issue: #109.