### PR TITLE
store raw bytes for unknown and deprecated attrs

### DIFF
--- a/bgpkit-parser-py/README.md
+++ b/bgpkit-parser-py/README.md
@@ -96,6 +96,25 @@ maturin publish --interpreter python3.11 --skip-existing
 
 ### Publish for MacOS
 
+#### M1-based
+
+**Minimum support version for M1 Macs is Python 3.8**
+
+Install multiple Python interpreters:
 ```bash
-maturin publish --skip-existing
+brew install python@3.8
+brew install python@3.9
+brew install python@3.10
+brew install python@3.11
 ```
+
+```bash
+maturin publish --interpreter python3.8 --skip-existing
+maturin publish --interpreter python3.9 --skip-existing
+maturin publish --interpreter python3.10 --skip-existing
+maturin publish --interpreter python3.11 --skip-existing
+```
+
+#### Intel-based
+
+- [ ] add support for packaging for Intel-based Macs 

--- a/bgpkit-parser/examples/deprecated_attributes.rs
+++ b/bgpkit-parser/examples/deprecated_attributes.rs
@@ -1,0 +1,19 @@
+//! This example shows how to iterate over all the BGP announcements with deprecated attributes.
+use bgpkit_parser::BgpkitParser;
+use serde_json::json;
+
+fn main() {
+    // the following file contains a number of deprecated attributes (28, BGP Entropy Label Capability)
+    for elem in BgpkitParser::new(
+        "https://archive.routeviews.org/route-views6/bgpdata/2023.06/UPDATES/updates.20230602.1330.bz2",
+    )
+    .unwrap()
+    {
+        if elem.deprecated.is_some() {
+            println!(
+                "{}",
+                json!(elem)
+            );
+        }
+    }
+}

--- a/bgpkit-parser/src/models/bgp/attributes/mod.rs
+++ b/bgpkit-parser/src/models/bgp/attributes/mod.rs
@@ -112,7 +112,7 @@ pub fn get_deprecated_attr_type(attr_type: u8) -> Option<&'static str> {
 /// BGP Attribute struct with attribute value and flag
 #[derive(Debug, PartialEq, Clone, Serialize, Eq)]
 pub struct Attribute {
-    pub attr_type: AttrType,
+    pub attr_type: u8,
     pub value: AttributeValue,
     pub flag: u8,
 }
@@ -137,6 +137,14 @@ pub enum AttributeValue {
     MpReachNlri(Nlri),
     MpUnreachNlri(Nlri),
     Development(Vec<u8>),
+    Deprecated(AttrRaw),
+    Unknown(AttrRaw),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Eq)]
+pub struct AttrRaw {
+    pub attr_type: u8,
+    pub bytes: Vec<u8>,
 }
 
 ///////////////////

--- a/bgpkit-parser/src/models/bgp/elem.rs
+++ b/bgpkit-parser/src/models/bgp/elem.rs
@@ -62,6 +62,10 @@ pub struct BgpElem {
     pub aggr_asn: Option<Asn>,
     pub aggr_ip: Option<IpAddr>,
     pub only_to_customer: Option<u32>,
+    /// unknown attributes formatted as (TYPE, RAW_BYTES)
+    pub unknown: Option<Vec<AttrRaw>>,
+    /// deprecated attributes formatted as (TYPE, RAW_BYTES)
+    pub deprecated: Option<Vec<AttrRaw>>,
 }
 
 impl Eq for BgpElem {}
@@ -120,6 +124,8 @@ impl Default for BgpElem {
             aggr_asn: None,
             aggr_ip: None,
             only_to_customer: None,
+            unknown: None,
+            deprecated: None,
         }
     }
 }

--- a/bgpkit-parser/src/parser/rislive/mod.rs
+++ b/bgpkit-parser/src/parser/rislive/mod.rs
@@ -190,6 +190,8 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
                                     aggr_asn: bgp_aggregator.0,
                                     aggr_ip: bgp_aggregator.1,
                                     only_to_customer: None,
+                                    unknown: None,
+                                    deprecated: None,
                                 });
                             }
                         }


### PR DESCRIPTION
This PR adds storing of raw bytes for deprecated and unknown attributes. This allows downstream applications to display and handle raw bytes for such attributes, useful during BGP debug sessions.

The following example will parse a updates file and pretty print any BGP announcements that contains deprecated path attributes:
```
cargo run --release -- https://archive.routeviews.org/route-views6/bgpdata/2023.06/UPDATES/updates.20230602.1330.bz2 --json | jq 'select(.deprecated != null)'
```