### PR TITLE
Clean up features and dependencies

### DIFF
--- a/bgpkit-parser/Cargo.toml
+++ b/bgpkit-parser/Cargo.toml
@@ -18,25 +18,58 @@ path = "src/bin/main.rs"
 required-features = ["build-binary"]
 
 [dependencies]
-chrono = "0.4.24"
-bytes = "1.4.0"
-enum-primitive-derive = "0.2"
-hex="0.4.3" # bmp/openbmp parsing
-ipnet = "2.7"
-itertools = "0.10.1"
-log="0.4"
-num-traits = "0.2"
-oneio = {version= "0.9.0", features=["lib_only"]}
-regex = "1"
-serde={version="1.0.130", features=["derive"]}
-serde_json = "1.0.69" # RIS Live parsing
 
+####################
+# Core BGP structs #
+####################
+enum-primitive-derive = {version="0.2", optional = true}
+serde={version="1.0", features=["derive"], optional = true}
+num-traits = {version = "0.2", optional = true}
+itertools = {version = "0.11.0", optional = true}
+ipnet = {version="2.7", optional = true}
+
+#######################
+# Parser dependencies #
+#######################
+bytes = {version = "1.4.0", optional = true}
+hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
+log= {version = "0.4", optional = true }
+oneio = {version= "0.11.0", features=["lib"], optional = true }
+regex = {version = "1", optional = true} # used in parser filter
+chrono = {version="0.4.24", optional = true} # parser filter
+serde_json = {version = "1.0", optional = true } # RIS Live parsing
+
+####################
+# CLI dependencies #
+####################
 env_logger = {version="0.10", optional=true}
 clap = {version= "4.0", features=["derive"], optional=true}
 
 [features]
-default = ["build-binary"]
-build-binary = ["clap", "env_logger"]
+default = ["parser"]
+models = [
+    "serde",
+    "enum-primitive-derive",
+    "ipnet",
+    "itertools",
+    "num-traits",
+]
+parser = [
+    "bytes",
+    "chrono",
+    "env_logger",
+    "hex",
+    "log",
+    "models",
+    "oneio",
+    "regex",
+    "serde_json",
+]
+build-binary = [
+    "clap",
+    "parser",
+    "env_logger"
+]
 
 [[bench]]
 name = "internals"
@@ -48,15 +81,14 @@ harness = false
 
 [dev-dependencies]
 anyhow = "1"
-bgpkit-broker = "0.5.1"
+bgpkit-broker = "0.6.2"
 kafka = "0.9.0"
-tungstenite= "0.18.0"
+tungstenite= "0.20.0"
 url = "2.1.0"
-criterion = {version= "0.4.0", features=["html_reports"]}
+criterion = {version= "0.5.1", features=["html_reports"]}
 rayon = "1.5.1"
 ureq = "2.6.2"
 bzip2 = "0.4"
 flate2 = "1.0.25"
 md5 = "0.7.0"
 which = "4.4.0"
-

--- a/bgpkit-parser/examples/real-time-ris-live-websocket.rs
+++ b/bgpkit-parser/examples/real-time-ris-live-websocket.rs
@@ -16,13 +16,10 @@ fn main() {
     // subscribe to messages from one collector
     // let msg = json!({"type": "ris_subscribe", "data": {"host": "rrc21"}}).to_string();
     let msg = json!({"type": "ris_subscribe", "data": null}).to_string();
-    socket.write_message(Message::Text(msg)).unwrap();
+    socket.send(Message::Text(msg)).unwrap();
 
     loop {
-        let msg = socket
-            .read_message()
-            .expect("Error reading message")
-            .to_string();
+        let msg = socket.read().expect("Error reading message").to_string();
         if msg.is_empty() {
             continue;
         }

--- a/bgpkit-parser/src/lib.rs
+++ b/bgpkit-parser/src/lib.rs
@@ -315,22 +315,18 @@ We support normal communities, extended communities, and large communities.
 #![allow(clippy::new_without_default)]
 #![allow(clippy::needless_range_loop)]
 
+#[cfg(feature = "models")]
 #[macro_use]
 extern crate enum_primitive_derive;
-extern crate core;
 
+#[cfg(feature = "parser")]
 pub mod error;
+#[cfg(feature = "models")]
 pub mod models;
+#[cfg(feature = "parser")]
 pub mod parser;
 
+#[cfg(feature = "models")]
 pub use models::BgpElem;
-pub use parser::bmp::parse_bmp_msg;
-pub use parser::bmp::parse_openbmp_header;
-pub use parser::bmp::parse_openbmp_msg;
-pub use parser::filter::*;
-pub use parser::iters::{ElemIterator, RecordIterator};
-pub use parser::mrt::parse_mrt_record;
-pub use parser::rislive::parse_ris_live_message;
-pub use parser::BgpkitParser;
-pub use parser::Elementor;
-pub use parser::ParserError;
+#[cfg(feature = "parser")]
+pub use parser::*;

--- a/bgpkit-parser/src/models/mod.rs
+++ b/bgpkit-parser/src/models/mod.rs
@@ -50,8 +50,6 @@ RFCs. Here is a list of them:
 
  */
 
-#![allow(dead_code)]
-
 mod bgp;
 mod err;
 mod mrt;

--- a/bgpkit-parser/src/parser/mod.rs
+++ b/bgpkit-parser/src/parser/mod.rs
@@ -11,15 +11,19 @@ pub mod rislive;
 
 pub(crate) use self::utils::*;
 pub(crate) use bgp::attributes::AttributeParser;
-pub(crate) use mrt::{
-    parse_bgp4mp, parse_mrt_record, parse_table_dump_message, parse_table_dump_v2_message,
-};
+pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message};
 
-pub use crate::error::{ParserError, ParserErrorWithBytes};
 use crate::models::MrtRecord;
-use crate::Filter;
+use filter::Filter;
 pub use mrt::mrt_elem::Elementor;
 use oneio::{get_cache_reader, get_reader};
+
+pub use crate::error::{ParserError, ParserErrorWithBytes};
+pub use bmp::{parse_bmp_msg, parse_openbmp_header, parse_openbmp_msg};
+pub use filter::*;
+pub use iters::*;
+pub use mrt::*;
+pub use rislive::parse_ris_live_message;
 
 pub struct BgpkitParser<R> {
     reader: R,

--- a/bgpkit-parser/src/parser/mrt/mrt_elem.rs
+++ b/bgpkit-parser/src/parser/mrt/mrt_elem.rs
@@ -95,7 +95,7 @@ fn get_relevant_attributes(
                 unknown.push(t);
             }
             AttributeValue::Deprecated(t) => {
-                deprecated.push((t));
+                deprecated.push(t);
             }
 
             AttributeValue::OriginatorId(_)


### PR DESCRIPTION
revise features into three major groups:
- `models`: only exporting BGP structs
- `parser`: the main feature
- `build-binary`: building `bgpkit-parser` cli tool

Each feature includes the previous feature, and the minimum required
features set is `models`.

This allows downstream libraries to consume bgpkit-parser defined BGP
structs without importing the whole library.

For example, when designing BGP RIB table processors, one sub-processor
does not really need to do any parsing, but only consume the parsed out
BGP messages. In such cases, the processor crate can import the crate
with `default-features=false, features=["models"]` config to avoid
bloating the crate.