### PR TITLE
add a few utility functions for `BgpElem`

### DIFF
--- a/bgpkit-parser/src/models/bgp/elem.rs
+++ b/bgpkit-parser/src/models/bgp/elem.rs
@@ -176,6 +176,37 @@ impl Display for BgpElem {
     }
 }
 
+impl BgpElem {
+    /// Returns true if the element is an announcement.
+    ///
+    /// Most of the time, users do not really need to get the type out, only needs to know if it is an announcement or a withdrawal.
+    pub fn is_announcement(&self) -> bool {
+        self.elem_type == ElemType::ANNOUNCE
+    }
+
+    /// Returns the AS path as a vector of ASNs in u32 format. Returns None if the AS path is not present or it contains AS set or confederated segments.
+    pub fn get_as_path_opt(&self) -> Option<Vec<u32>> {
+        match &self.as_path {
+            Some(as_path) => as_path.to_u32_vec(),
+            None => None,
+        }
+    }
+
+    /// Returns the origin AS number as u32. Returns None if the origin AS number is not present or it's a AS set.
+    pub fn get_origin_asn_opt(&self) -> Option<u32> {
+        match &self.origin_asns {
+            Some(origin_asns) => {
+                if origin_asns.len() == 1 {
+                    Some(origin_asns[0].asn)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
1. `is_announcement()`: true if the elem is an announcement;
2. `get_as_path_opt()`: return Some(Vec<u32>) if AS path exists and no AS set or confederated segs
3. `get_origin_asn_opt()`: return Some(u32) as the origin ASN if it is announcement and the path exists.