### PR TITLE
Fix broken link in README

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ BGPKIT Parser has the following features:
 
 # Examples
 
-For complete examples, check out the [examples folder](https://github.com/bgpkit/bgpkit-parser/examples).
+For complete examples, check out the [examples folder](https://github.com/bgpkit/bgpkit-parser/tree/main/examples).
 
 ## Parsing single MRT file
 


### PR DESCRIPTION
Hi there!

As I was reading through the README, I noticed a broken link to the examples directory. This pull request updates the `src/lib.rs` file (since this repo uses [cargo-readme](https://github.com/livioribeiro/cargo-readme)) to include the Git branch name in the GitHub URL.