### PR TITLE
Add full serde support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       run: cargo build
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
 
     - name: Run format check
       run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ parser = [
 cli = [
     "clap",
     "parser",
-    "env_logger"
+    "env_logger",
+    "serde",
+    "serde_json"
 ]
 rislive = [
     "parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ clap = {version= "4.0", features=["derive"], optional=true}
 [features]
 default = ["parser"]
 models = [
-    "serde",
     "enum-primitive-derive",
     "ipnet",
     "itertools",
@@ -69,6 +68,10 @@ cli = [
     "clap",
     "parser",
     "env_logger"
+]
+serde = [
+    "dep:serde",
+    "ipnet/serde",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,17 +57,21 @@ parser = [
     "bytes",
     "chrono",
     "env_logger",
-    "hex",
     "log",
     "models",
     "oneio",
     "regex",
-    "serde_json",
 ]
 cli = [
     "clap",
     "parser",
     "env_logger"
+]
+rislive = [
+    "parser",
+    "serde",
+    "serde_json",
+    "hex",
 ]
 serde = [
     "dep:serde",
@@ -95,3 +99,18 @@ bzip2 = "0.4"
 flate2 = "1.0.25"
 md5 = "0.7.0"
 which = "4.4.0"
+serde_json = "1.0"
+hex = "0.4.3"
+
+# This list only includes examples which require additional features to run. These are more in the examples directory.
+[[example]]
+name = "real-time-ris-live-websocket"
+required-features = ["rislive"]
+
+[[example]]
+name = "peer_index_table"
+required-features = ["serde"]
+
+[[example]]
+name = "deprecated_attributes"
+required-features = ["serde"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,20 +37,19 @@ impl Error for ParserErrorWithBytes {}
 
 /// implement Display trait for Error which satistifies the std::error::Error
 /// trait's requirement (must implement Display and Debug traits, Debug already derived)
-impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let message = match self {
-            ParserError::IoError(e) => e.to_string(),
-            ParserError::EofError(e) => e.to_string(),
-            ParserError::ParseError(s) => s.to_owned(),
-            ParserError::TruncatedMsg(s) => s.to_owned(),
-            ParserError::Unsupported(s) => s.to_owned(),
-            ParserError::EofExpected => "reach end of file".to_string(),
-            ParserError::OneIoError(e) => e.to_string(),
-            ParserError::FilterError(e) => e.to_owned(),
-            ParserError::IoNotEnoughBytes() => "Not enough bytes to read".to_string(),
-        };
-        write!(f, "Error: {}", message)
+impl Display for ParserError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ParserError::IoError(e) => write!(f, "Error: {}", e),
+            ParserError::EofError(e) => write!(f, "Error: {}", e),
+            ParserError::ParseError(s) => write!(f, "Error: {}", s),
+            ParserError::TruncatedMsg(s) => write!(f, "Error: {}", s),
+            ParserError::Unsupported(s) => write!(f, "Error: {}", s),
+            ParserError::EofExpected => write!(f, "Error: reach end of file"),
+            ParserError::OneIoError(e) => write!(f, "Error: {}", e),
+            ParserError::FilterError(e) => write!(f, "Error: {}", e),
+            ParserError::IoNotEnoughBytes() => write!(f, "Error: Not enough bytes to read"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ we need to subscribe to a specific data stream. In this example, we subscribe to
 from on collector (`rrc21`). We can then loop and read messages from the websocket.
 
 ```no_run
+# #[cfg(feature = "rislive")]
 use bgpkit_parser::parse_ris_live_message;
 use serde_json::json;
 use tungstenite::{connect, Message};
@@ -153,6 +154,7 @@ fn main() {
 
     loop {
         let msg = socket.read_message().expect("Error reading message").to_string();
+#       #[cfg(feature = "rislive")]
         if let Ok(elems) = parse_ris_live_message(msg.as_str()) {
             for elem in elems {
                 println!("{}", elem);

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -179,7 +179,7 @@ impl Serialize for AsPath {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        serializer.collect_str(self)
     }
 }
 

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -1,6 +1,4 @@
 use crate::models::*;
-use itertools::Itertools;
-use serde::{Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 /// Enum of AS path segment.
@@ -19,6 +17,14 @@ impl AsPathSegment {
             AsPathSegment::AsSet(_) => 1,
             AsPathSegment::ConfedSequence(_) | AsPathSegment::ConfedSet(_) => 0,
         }
+    }
+
+    /// Gets if a segment represents the local members of an autonomous system confederation.
+    /// Shorthand for `matches!(x, AsPathSegment::ConfedSequence(_) | AsPathSegment::ConfedSet(_))`.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc3065#section-5>
+    pub fn is_confed(&self) -> bool {
+        matches!(self, AsPathSegment::ConfedSequence(_) | AsPathSegment::ConfedSet(_))
     }
 }
 
@@ -174,13 +180,220 @@ impl Display for AsPath {
     }
 }
 
-impl Serialize for AsPath {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_str(self)
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::borrow::Cow;
+    use serde::{Serialize, Serializer, Deserialize, Deserializer};
+    use serde::de::{SeqAccess, Visitor};
+    use serde::ser::SerializeSeq;
+    use super::*;
+
+    /// Segment type names using names from RFC3065.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc3065#section-5>
+    #[allow(non_camel_case_types)]
+    #[derive(Serialize, Deserialize)]
+    enum SegmentType {
+        AS_SET,
+        AS_SEQUENCE,
+        AS_CONFED_SEQUENCE,
+        AS_CONFED_SET,
     }
+
+    #[derive(Serialize, Deserialize)]
+    struct VerboseSegment<'s> {
+        ty: SegmentType,
+        values: Cow<'s, [Asn]>,
+    }
+
+    impl Serialize for AsPathSegment {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+            let (ty, elements) = match self {
+                AsPathSegment::AsSequence(x) => (SegmentType::AS_SEQUENCE, x.as_ref()),
+                AsPathSegment::AsSet(x) => (SegmentType::AS_SET, x.as_ref()),
+                AsPathSegment::ConfedSequence(x) => (SegmentType::AS_CONFED_SEQUENCE, x.as_ref()),
+                AsPathSegment::ConfedSet(x) => (SegmentType::AS_CONFED_SET, x.as_ref()),
+            };
+
+            let verbose = VerboseSegment {
+                ty,
+                values: Cow::Borrowed(elements),
+            };
+
+            verbose.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for AsPathSegment {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+            let verbose = VerboseSegment::deserialize(deserializer)?;
+
+            let values = verbose.values.into_owned();
+            match verbose.ty {
+                SegmentType::AS_SET => Ok(AsPathSegment::AsSet(values)),
+                SegmentType::AS_SEQUENCE => Ok(AsPathSegment::AsSequence(values)),
+                SegmentType::AS_CONFED_SEQUENCE => Ok(AsPathSegment::ConfedSequence(values)),
+                SegmentType::AS_CONFED_SET => Ok(AsPathSegment::ConfedSet(values)),
+            }
+        }
+    }
+
+    /// Check if we can serialize an `AsPath` using the simplified format and get the number of
+    /// elements to do so. The ambiguities that could prevent us from doing so are confederation
+    /// segments and adjacent sequence segments.
+    fn simplified_format_len(segments: &[AsPathSegment]) -> Option<usize> {
+        let mut elements = 0;
+        let mut prev_was_sequence = false;
+        for segment in segments {
+            match segment {
+                AsPathSegment::AsSequence(seq) if !prev_was_sequence => {
+                    prev_was_sequence = true;
+                    elements += seq.len();
+                },
+                AsPathSegment::AsSet(_) => {
+                    prev_was_sequence = false;
+                    elements += 1;
+                },
+                _ => return None,
+            }
+        }
+
+        Some(elements)
+    }
+
+    /// # Serialization format
+    /// For the sake of readability and ease of use within other applications, there are verbose and
+    /// simplified variants for serialization.
+    ///
+    /// ## Simplified format
+    /// The simplified format is the default preferred serialization format. This format does not
+    /// cover confederation segments and involves a single list of ASNs within the path sequence.
+    /// For sets, a list of set members is used in place of an ASN.
+    /// ```rust
+    /// # use bgpkit_parser::models::{Asn, AsPath};
+    /// # use bgpkit_parser::models::AsPathSegment::*;
+    ///
+    /// let a: AsPath = serde_json::from_str("[123, 942, 102]").unwrap();
+    /// let b: AsPath = serde_json::from_str("[231, 432, [643, 836], 352]").unwrap();
+    ///
+    /// assert_eq!(&a.segments, &[
+    ///     AsSequence(vec![Asn::from(123), Asn::from(942), Asn::from(102)])
+    /// ]);
+    /// assert_eq!(&b.segments, &[
+    ///     AsSequence(vec![Asn::from(231), Asn::from(432)]),
+    ///     AsSet(vec![Asn::from(643), Asn::from(836)]),
+    ///     AsSequence(vec![Asn::from(352)])
+    /// ]);
+    /// ```
+    ///
+    /// ## Verbose format
+    /// The verbose format serves as the fallback format for when the simplified format can not be
+    /// used due to ambiguity. This happens when confederation segments are present, or multiple
+    /// sequences occur back to back. In this format, segments are explicitly seperated and labeled.
+    /// Segment types, denoted by the `ty` field, correspond to the names used within RFC3065
+    /// (`AS_SET`, `AS_SEQUENCE`, `AS_CONFED_SEQUENCE`, `AS_CONFED_SET`).
+    /// ```rust
+    /// # use bgpkit_parser::models::{Asn, AsPath};
+    /// # use bgpkit_parser::models::AsPathSegment::*;
+    ///
+    /// let a = r#"[
+    ///     { "ty": "AS_CONFED_SEQUENCE", "values": [123, 942] },
+    ///     { "ty": "AS_SEQUENCE", "values": [773] },
+    ///     { "ty": "AS_SEQUENCE", "values": [382, 293] }
+    /// ]"#;
+    ///
+    /// let parsed: AsPath = serde_json::from_str(a).unwrap();
+    /// assert_eq!(&parsed.segments, &[
+    ///     ConfedSequence(vec![Asn::from(123), Asn::from(942)]),
+    ///     AsSequence(vec![Asn::from(773)]),
+    ///     AsSequence(vec![Asn::from(382), Asn::from(293)])
+    /// ]);
+    /// ```
+    impl Serialize for AsPath {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+            if let Some(num_elements) = simplified_format_len(&self.segments) {
+                // Serialize simplified format
+                let mut seq_serializer = serializer.serialize_seq(Some(num_elements))?;
+
+                for segment in &self.segments {
+                    match segment {
+                        AsPathSegment::AsSequence(elements) => {
+                            elements.iter().try_for_each(|x| {
+                                seq_serializer.serialize_element(x)
+                            })?;
+                        }
+                        AsPathSegment::AsSet(x) => seq_serializer.serialize_element(x)?,
+                        _ => unreachable!("simplified_format_len checked for confed segments")
+                    }
+                }
+                return seq_serializer.end();
+            }
+
+            // Serialize verbose format
+            serializer.collect_seq(&self.segments)
+        }
+    }
+
+    struct AsPathVisitor;
+
+    impl<'de> Visitor<'de> for AsPathVisitor {
+        type Value = AsPath;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("list of AS_PATH segments")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            // Technically, we can handle an input that mixes the simplified and verbose formats,
+            // but we do not want to document this behavior as it may change in future updates.
+            #[derive(Deserialize)]
+            #[serde(untagged)]
+            enum PathElement {
+                SequenceElement(Asn),
+                Set(Vec<Asn>),
+                Verbose(AsPathSegment),
+            }
+
+            let mut append_new_sequence = false;
+            let mut segments = Vec::new();
+            while let Some(element) = seq.next_element()? {
+                match element {
+                    PathElement::SequenceElement(x) => {
+                        if append_new_sequence {
+                            // If the input is mixed between verbose and regular segments, this flag
+                            // is used to prevent appending to a verbose sequence.
+                            append_new_sequence = false;
+                            segments.push(AsPathSegment::AsSequence(Vec::new()));
+                        }
+
+                        if let Some(AsPathSegment::AsSequence(last_sequence)) = segments.last_mut() {
+                            last_sequence.push(x);
+                        } else {
+                            segments.push(AsPathSegment::AsSequence(vec![x]));
+                        }
+                    },
+                    PathElement::Set(values) => {
+                        segments.push(AsPathSegment::AsSet(values));
+                    },
+                    PathElement::Verbose(verbose) => {
+                        segments.push(verbose);
+                    }
+                }
+            }
+
+            Ok(AsPath { segments })
+        }
+    }
+
+    impl<'de> Deserialize<'de> for AsPath {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+            deserializer.deserialize_seq(AsPathVisitor)
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -139,20 +139,38 @@ impl AsPath {
 
 impl Display for AsPath {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.segments()
-                .iter()
-                .map(|seg| match seg {
-                    AsPathSegment::AsSequence(v) | AsPathSegment::ConfedSequence(v) =>
-                        v.iter().join(" "),
-                    AsPathSegment::AsSet(v) | AsPathSegment::ConfedSet(v) => {
-                        format!("{{{}}}", v.iter().join(","))
+        for (index, segment) in self.segments().iter().enumerate() {
+            if index != 0 {
+                write!(f, " ")?;
+            }
+
+            match segment {
+                AsPathSegment::AsSequence(v) | AsPathSegment::ConfedSequence(v) => {
+                    let mut asn_iter = v.iter();
+                    if let Some(first_element) = asn_iter.next() {
+                        write!(f, "{}", first_element)?;
+
+                        for asn in asn_iter {
+                            write!(f, " {}", asn)?;
+                        }
                     }
-                })
-                .join(" ")
-        )
+                },
+                AsPathSegment::AsSet(v) | AsPathSegment::ConfedSet(v) => {
+                    write!(f, "{{")?;
+                    let mut asn_iter = v.iter();
+                    if let Some(first_element) = asn_iter.next() {
+                        write!(f, "{}", first_element)?;
+
+                        for asn in asn_iter {
+                            write!(f, ",{}", asn)?;
+                        }
+                    }
+                    write!(f, "}}")?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/models/bgp/attributes/atomic_aggregate.rs
+++ b/src/models/bgp/attributes/atomic_aggregate.rs
@@ -22,6 +22,6 @@ impl Serialize for AtomicAggregate {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        serializer.collect_str(self)
     }
 }

--- a/src/models/bgp/attributes/atomic_aggregate.rs
+++ b/src/models/bgp/attributes/atomic_aggregate.rs
@@ -1,8 +1,8 @@
-use serde::{Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AtomicAggregate {
     NAG = 0,
     AG = 1,
@@ -14,14 +14,5 @@ impl Display for AtomicAggregate {
             AtomicAggregate::NAG => write!(f, "NAG"),
             AtomicAggregate::AG => write!(f, "AG"),
         }
-    }
-}
-
-impl Serialize for AtomicAggregate {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_str(self)
     }
 }

--- a/src/models/bgp/attributes/atomic_aggregate.rs
+++ b/src/models/bgp/attributes/atomic_aggregate.rs
@@ -10,18 +10,10 @@ pub enum AtomicAggregate {
 
 impl Display for AtomicAggregate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                AtomicAggregate::NAG => {
-                    "NAG"
-                }
-                AtomicAggregate::AG => {
-                    "AG"
-                }
-            }
-        )
+        match self {
+            AtomicAggregate::NAG => write!(f, "NAG"),
+            AtomicAggregate::AG => write!(f, "AG"),
+        }
     }
 }
 

--- a/src/models/bgp/attributes/mod.rs
+++ b/src/models/bgp/attributes/mod.rs
@@ -5,7 +5,6 @@ mod nlri;
 mod origin;
 
 use crate::models::network::*;
-use serde::Serialize;
 use std::net::IpAddr;
 
 use crate::models::*;
@@ -54,7 +53,8 @@ pub enum AttributeFlagsBit {
 /// To see the full list, check out IANA at:
 /// <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2>
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AttrType {
     RESERVED = 0,
     ORIGIN = 1,
@@ -110,7 +110,8 @@ pub fn get_deprecated_attr_type(attr_type: u8) -> Option<&'static str> {
 }
 
 /// BGP Attribute struct with attribute value and flag
-#[derive(Debug, PartialEq, Clone, Serialize, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Attribute {
     pub attr_type: u8,
     pub value: AttributeValue,
@@ -118,7 +119,8 @@ pub struct Attribute {
 }
 
 /// The `AttributeValue` enum represents different kinds of Attribute values.
-#[derive(Debug, PartialEq, Clone, Serialize, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AttributeValue {
     Origin(Origin),
     AsPath(AsPath),
@@ -141,7 +143,8 @@ pub enum AttributeValue {
     Unknown(AttrRaw),
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttrRaw {
     pub attr_type: u8,
     pub bytes: Vec<u8>,

--- a/src/models/bgp/attributes/nlri.rs
+++ b/src/models/bgp/attributes/nlri.rs
@@ -1,7 +1,7 @@
 use crate::models::*;
-use serde::Serialize;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Nlri {
     pub afi: Afi,
     pub safi: Safi,
@@ -9,7 +9,8 @@ pub struct Nlri {
     pub prefixes: Vec<NetworkPrefix>,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MpReachableNlri {
     afi: Afi,
     safi: Safi,
@@ -34,6 +35,7 @@ impl MpReachableNlri {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MpUnreachableNlri {
     afi: Afi,
     safi: Safi,

--- a/src/models/bgp/attributes/origin.rs
+++ b/src/models/bgp/attributes/origin.rs
@@ -11,12 +11,11 @@ pub enum Origin {
 
 impl Display for Origin {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Origin::IGP => "IGP",
-            Origin::EGP => "EGP",
-            Origin::INCOMPLETE => "INCOMPLETE",
-        };
-        write!(f, "{}", s)
+        match self {
+            Origin::IGP => write!(f, "IGP"),
+            Origin::EGP => write!(f, "EGP"),
+            Origin::INCOMPLETE => write!(f, "INCOMPLETE"),
+        }
     }
 }
 

--- a/src/models/bgp/attributes/origin.rs
+++ b/src/models/bgp/attributes/origin.rs
@@ -24,6 +24,6 @@ impl Serialize for Origin {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        serializer.collect_str(self)
     }
 }

--- a/src/models/bgp/attributes/origin.rs
+++ b/src/models/bgp/attributes/origin.rs
@@ -1,8 +1,8 @@
-use serde::{Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Origin {
     IGP = 0,
     EGP = 1,
@@ -16,14 +16,5 @@ impl Display for Origin {
             Origin::EGP => write!(f, "EGP"),
             Origin::INCOMPLETE => write!(f, "INCOMPLETE"),
         }
-    }
-}
-
-impl Serialize for Origin {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_str(self)
     }
 }

--- a/src/models/bgp/capabilities.rs
+++ b/src/models/bgp/capabilities.rs
@@ -1,10 +1,10 @@
 use num_traits::FromPrimitive;
-use serde::Serialize;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 /// BGP capability parsing error
-#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum BgpCapabilityParsingError {
     Unassigned(u8),
     DeprecatedCode(u8),
@@ -38,7 +38,8 @@ impl Display for BgpCapabilityParsingError {
 impl Error for BgpCapabilityParsingError {}
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpCapabilityType {
     MULTIPROTOCOL_EXTENSIONS_FOR_BGP_4 = 1,
     ROUTE_REFRESH_CAPABILITY_FOR_BGP_4 = 2,

--- a/src/models/bgp/community.rs
+++ b/src/models/bgp/community.rs
@@ -181,12 +181,15 @@ pub struct Opaque {
 // DISPLAY //
 /////////////
 
-fn bytes_to_string(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .map(|x| format!("{:02X}", x))
-        .collect::<Vec<String>>()
-        .join("")
+struct ToHexString<'a>(&'a [u8]);
+
+impl Display for ToHexString<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
 }
 
 impl Display for Community {
@@ -221,7 +224,7 @@ impl Display for ExtendedCommunity {
                     ec.ec_type,
                     ec.ec_subtype,
                     ec.global_administrator,
-                    bytes_to_string(&ec.local_administrator)
+                    ToHexString(&ec.local_administrator)
                 )
             }
             ExtendedCommunity::TransitiveIpv4AddressSpecific(ec)
@@ -232,7 +235,7 @@ impl Display for ExtendedCommunity {
                     ec.ec_type,
                     ec.ec_subtype,
                     ec.global_administrator,
-                    bytes_to_string(&ec.local_administrator)
+                    ToHexString(&ec.local_administrator)
                 )
             }
             ExtendedCommunity::TransitiveFourOctetAsSpecific(ec)
@@ -243,7 +246,7 @@ impl Display for ExtendedCommunity {
                     ec.ec_type,
                     ec.ec_subtype,
                     ec.global_administrator,
-                    bytes_to_string(&ec.local_administrator)
+                    ToHexString(&ec.local_administrator)
                 )
             }
             ExtendedCommunity::TransitiveOpaque(ec)
@@ -253,7 +256,7 @@ impl Display for ExtendedCommunity {
                     "ecop:{}:{}:{}",
                     ec.ec_type,
                     ec.ec_subtype,
-                    bytes_to_string(&ec.value)
+                    ToHexString(&ec.value)
                 )
             }
             ExtendedCommunity::Ipv6AddressSpecific(ec) => {
@@ -263,11 +266,11 @@ impl Display for ExtendedCommunity {
                     ec.ec_type,
                     ec.ec_subtype,
                     ec.global_administrator,
-                    bytes_to_string(&ec.local_administrator)
+                    ToHexString(&ec.local_administrator)
                 )
             }
             ExtendedCommunity::Raw(ec) => {
-                write!(f, "ecraw:{}", bytes_to_string(ec))
+                write!(f, "ecraw:{}", ToHexString(ec))
             }
         }
     }

--- a/src/models/bgp/community.rs
+++ b/src/models/bgp/community.rs
@@ -1,6 +1,6 @@
 use crate::models::Asn;
 use serde::Serialize;
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter, Write};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Debug, PartialEq, Copy, Clone, Eq)]
@@ -179,31 +179,19 @@ fn bytes_to_string(bytes: &[u8]) -> String {
         .join("")
 }
 
-impl std::fmt::Display for Community {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Community::NoExport => {
-                    "no-export".to_string()
-                }
-                Community::NoAdvertise => {
-                    "no-advertise".to_string()
-                }
-                Community::NoExportSubConfed => {
-                    "no-export-sub-confed".to_string()
-                }
-                Community::Custom(asn, value) => {
-                    format!("{}:{}", asn, value)
-                }
-            }
-        )
+impl Display for Community {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Community::NoExport => write!(f, "no-export"),
+            Community::NoAdvertise => write!(f, "no-advertise"),
+            Community::NoExportSubConfed => write!(f, "no-export-sub-confed"),
+            Community::Custom(asn, value) => write!(f, "{}:{}", asn, value),
+        }
     }
 }
 
-impl std::fmt::Display for LargeCommunity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for LargeCommunity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "lg:{}:{}:{}",
@@ -212,85 +200,76 @@ impl std::fmt::Display for LargeCommunity {
     }
 }
 
-impl std::fmt::Display for ExtendedCommunity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                ExtendedCommunity::TransitiveTwoOctetAsSpecific(ec)
-                | ExtendedCommunity::NonTransitiveTwoOctetAsSpecific(ec) => {
-                    format!(
-                        "ecas2:{}:{}:{}:{}",
-                        ec.ec_type,
-                        ec.ec_subtype,
-                        ec.global_administrator,
-                        bytes_to_string(&ec.local_administrator)
-                    )
-                }
-                ExtendedCommunity::TransitiveIpv4AddressSpecific(ec)
-                | ExtendedCommunity::NonTransitiveIpv4AddressSpecific(ec) => {
-                    format!(
-                        "ecv4:{}:{}:{}:{}",
-                        ec.ec_type,
-                        ec.ec_subtype,
-                        ec.global_administrator,
-                        bytes_to_string(&ec.local_administrator)
-                    )
-                }
-                ExtendedCommunity::TransitiveFourOctetAsSpecific(ec)
-                | ExtendedCommunity::NonTransitiveFourOctetAsSpecific(ec) => {
-                    format!(
-                        "ecas4:{}:{}:{}:{}",
-                        ec.ec_type,
-                        ec.ec_subtype,
-                        ec.global_administrator,
-                        bytes_to_string(&ec.local_administrator)
-                    )
-                }
-                ExtendedCommunity::TransitiveOpaque(ec)
-                | ExtendedCommunity::NonTransitiveOpaque(ec) => {
-                    format!(
-                        "ecop:{}:{}:{}",
-                        ec.ec_type,
-                        ec.ec_subtype,
-                        bytes_to_string(&ec.value)
-                    )
-                }
-                ExtendedCommunity::Ipv6AddressSpecific(ec) => {
-                    format!(
-                        "ecv6:{}:{}:{}:{}",
-                        ec.ec_type,
-                        ec.ec_subtype,
-                        ec.global_administrator,
-                        bytes_to_string(&ec.local_administrator)
-                    )
-                }
-                ExtendedCommunity::Raw(ec) => {
-                    format!("ecraw:{}", bytes_to_string(ec))
-                }
+impl Display for ExtendedCommunity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtendedCommunity::TransitiveTwoOctetAsSpecific(ec)
+            | ExtendedCommunity::NonTransitiveTwoOctetAsSpecific(ec) => {
+                write!(
+                    f,
+                    "ecas2:{}:{}:{}:{}",
+                    ec.ec_type,
+                    ec.ec_subtype,
+                    ec.global_administrator,
+                    bytes_to_string(&ec.local_administrator)
+                )
             }
-        )
+            ExtendedCommunity::TransitiveIpv4AddressSpecific(ec)
+            | ExtendedCommunity::NonTransitiveIpv4AddressSpecific(ec) => {
+                write!(
+                    f,
+                    "ecv4:{}:{}:{}:{}",
+                    ec.ec_type,
+                    ec.ec_subtype,
+                    ec.global_administrator,
+                    bytes_to_string(&ec.local_administrator)
+                )
+            }
+            ExtendedCommunity::TransitiveFourOctetAsSpecific(ec)
+            | ExtendedCommunity::NonTransitiveFourOctetAsSpecific(ec) => {
+                write!(
+                    f,
+                    "ecas4:{}:{}:{}:{}",
+                    ec.ec_type,
+                    ec.ec_subtype,
+                    ec.global_administrator,
+                    bytes_to_string(&ec.local_administrator)
+                )
+            }
+            ExtendedCommunity::TransitiveOpaque(ec)
+            | ExtendedCommunity::NonTransitiveOpaque(ec) => {
+                write!(
+                    f,
+                    "ecop:{}:{}:{}",
+                    ec.ec_type,
+                    ec.ec_subtype,
+                    bytes_to_string(&ec.value)
+                )
+            }
+            ExtendedCommunity::Ipv6AddressSpecific(ec) => {
+                write!(
+                    f,
+                    "ecv6:{}:{}:{}:{}",
+                    ec.ec_type,
+                    ec.ec_subtype,
+                    ec.global_administrator,
+                    bytes_to_string(&ec.local_administrator)
+                )
+            }
+            ExtendedCommunity::Raw(ec) => {
+                write!(f, "ecraw:{}", bytes_to_string(ec))
+            }
+        }
     }
 }
 
-impl std::fmt::Display for MetaCommunity {
+impl Display for MetaCommunity {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                MetaCommunity::Community(c) => {
-                    c.to_string()
-                }
-                MetaCommunity::ExtendedCommunity(c) => {
-                    c.to_string()
-                }
-                MetaCommunity::LargeCommunity(c) => {
-                    c.to_string()
-                }
-            }
-        )
+        match self {
+            MetaCommunity::Community(c) => write!(f, "{}", c),
+            MetaCommunity::ExtendedCommunity(c) => write!(f, "{}", c),
+            MetaCommunity::LargeCommunity(c) => write!(f, "{}", c),
+        }
     }
 }
 

--- a/src/models/bgp/community.rs
+++ b/src/models/bgp/community.rs
@@ -1,9 +1,10 @@
 use crate::models::Asn;
-use serde::Serialize;
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Debug, PartialEq, Copy, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum MetaCommunity {
     Community(Community),
     ExtendedCommunity(ExtendedCommunity),
@@ -11,6 +12,7 @@ pub enum MetaCommunity {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Community {
     NoExport,
     NoAdvertise,
@@ -25,6 +27,7 @@ pub enum Community {
 /// Large community is displayed as `lg:GLOBAL_ADMINISTRATOR:LOCAL_DATA_1:LOCAL_DATA_2`, where `lg`
 /// is a prefix for large community.
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LargeCommunity {
     pub global_administrator: u32,
     pub local_data: [u32; 2],
@@ -41,6 +44,7 @@ impl LargeCommunity {
 
 /// Type definitions of extended communities
 #[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtendedCommunityType {
     // transitive types
     TransitiveTwoOctetAsSpecific = 0x00,
@@ -94,6 +98,7 @@ pub enum ExtendedCommunityType {
 /// - `ecop:` stands for `Extended Community Opaque`
 /// - `ecraw:` stands for `Extended Community Raw`
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtendedCommunity {
     TransitiveTwoOctetAsSpecific(TwoOctetAsSpecific),
     TransitiveIpv4AddressSpecific(Ipv4AddressSpecific),
@@ -108,6 +113,7 @@ pub enum ExtendedCommunity {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ipv6AddressSpecific {
     pub ec_type: u8,
     pub ec_subtype: u8,
@@ -121,6 +127,7 @@ pub struct Ipv6AddressSpecific {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.1>
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TwoOctetAsSpecific {
     pub ec_type: u8,
     pub ec_subtype: u8,
@@ -134,6 +141,7 @@ pub struct TwoOctetAsSpecific {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc5668#section-2>
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FourOctetAsSpecific {
     pub ec_type: u8,
     pub ec_subtype: u8,
@@ -147,6 +155,7 @@ pub struct FourOctetAsSpecific {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.2>
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ipv4AddressSpecific {
     pub ec_type: u8,
     pub ec_subtype: u8,
@@ -160,6 +169,7 @@ pub struct Ipv4AddressSpecific {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.3>
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Opaque {
     pub ec_type: u8,
     pub ec_subtype: u8,
@@ -272,31 +282,3 @@ impl Display for MetaCommunity {
         }
     }
 }
-
-///////////////
-// SERIALIZE //
-///////////////
-
-macro_rules! impl_serialize {
-    ($a:ident) => {
-        impl Serialize for $a {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                serializer.collect_str(self)
-            }
-        }
-
-        impl<'de> serde::Deserialize<'de> for $a {
-            fn deserialize<D>(_: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
-                todo!()
-            }
-        }
-    };
-}
-
-impl_serialize!(Community);
-impl_serialize!(ExtendedCommunity);
-impl_serialize!(LargeCommunity);
-impl_serialize!(MetaCommunity);

--- a/src/models/bgp/community.rs
+++ b/src/models/bgp/community.rs
@@ -308,6 +308,12 @@ macro_rules! impl_serialize {
                 serializer.collect_str(self)
             }
         }
+
+        impl<'de> serde::Deserialize<'de> for $a {
+            fn deserialize<D>(_: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+                todo!()
+            }
+        }
     };
 }
 

--- a/src/models/bgp/community.rs
+++ b/src/models/bgp/community.rs
@@ -305,7 +305,7 @@ macro_rules! impl_serialize {
             where
                 S: serde::Serializer,
             {
-                serializer.serialize_str(self.to_string().as_str())
+                serializer.collect_str(self)
             }
         }
     };

--- a/src/models/bgp/elem.rs
+++ b/src/models/bgp/elem.rs
@@ -1,6 +1,6 @@
 use crate::models::*;
 use itertools::Itertools;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
@@ -10,22 +10,11 @@ use std::str::FromStr;
 ///
 /// - ANNOUNCE: announcement/reachable prefix
 /// - WITHDRAW: withdrawn/unreachable prefix
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename = "lowercase")]
 pub enum ElemType {
     ANNOUNCE,
     WITHDRAW,
-}
-
-impl Serialize for ElemType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(match self {
-            ElemType::ANNOUNCE => "announce",
-            ElemType::WITHDRAW => "withdraw",
-        })
-    }
 }
 
 impl ElemType {

--- a/src/models/bgp/elem.rs
+++ b/src/models/bgp/elem.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
@@ -10,7 +9,8 @@ use std::str::FromStr;
 ///
 /// - ANNOUNCE: announcement/reachable prefix
 /// - WITHDRAW: withdrawn/unreachable prefix
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[serde(rename = "lowercase")]
 pub enum ElemType {
     ANNOUNCE,
@@ -32,7 +32,8 @@ impl ElemType {
 ///
 /// Note: it consumes more memory to construct BGP elements due to duplicate information
 /// shared between multiple elements of one MRT record.
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpElem {
     pub timestamp: f64,
     #[serde(rename = "type")]
@@ -75,7 +76,8 @@ impl Ord for BgpElem {
 }
 
 /// Reference version of the [BgpElem] struct.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct BgpElemRef<'a> {
     pub timestamp: &'a f64,
     pub elem_type: &'a ElemType,

--- a/src/models/bgp/elem.rs
+++ b/src/models/bgp/elem.rs
@@ -205,6 +205,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_default() {
         let elem = BgpElem {
             timestamp: 0.0,

--- a/src/models/bgp/elem.rs
+++ b/src/models/bgp/elem.rs
@@ -155,7 +155,8 @@ impl Display for BgpElem {
             ElemType::ANNOUNCE => "A",
             ElemType::WITHDRAW => "W",
         };
-        let format = format!(
+        write!(
+            f,
             "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             t,
             &self.timestamp,
@@ -171,8 +172,7 @@ impl Display for BgpElem {
             option_to_string!(&self.atomic),
             option_to_string!(&self.aggr_asn),
             option_to_string!(&self.aggr_ip),
-        );
-        write!(f, "{}", format)
+        )
     }
 }
 

--- a/src/models/bgp/elem.rs
+++ b/src/models/bgp/elem.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 /// - WITHDRAW: withdrawn/unreachable prefix
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[serde(rename = "lowercase")]
+#[cfg_attr(feature = "serde", serde(rename = "lowercase"))]
 pub enum ElemType {
     ANNOUNCE,
     WITHDRAW,
@@ -36,7 +36,7 @@ impl ElemType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpElem {
     pub timestamp: f64,
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub elem_type: ElemType,
     pub peer_ip: IpAddr,
     pub peer_asn: Asn,

--- a/src/models/bgp/error.rs
+++ b/src/models/bgp/error.rs
@@ -3,12 +3,12 @@
 //! The full list of IANA error code assignments for BGP can be viewed at here:
 //! <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-3>.
 use num_traits::FromPrimitive;
-use serde::Serialize;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 /// Error for parsing BGP error code
-#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpErrorCodeParsingError {
     UnknownCode(u8),
     UnknownSubcode(u8),
@@ -87,7 +87,8 @@ pub fn parse_error_codes(
 ///
 /// <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-4>
 #[allow(non_camel_case_types)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpError {
     Reserved,
     MessageHeaderError(MessageHeaderErrorSubcode),
@@ -105,7 +106,8 @@ pub enum BgpError {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MessageHeaderErrorSubcode {
     UNSPECIFIC = 0,
     CONNECTION_NOT_SYNCHRONIZED = 1,
@@ -120,7 +122,8 @@ pub enum MessageHeaderErrorSubcode {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum OpenMessageErrorSubcode {
     UNSPECIFIC = 0,
     UNSUPPORTED_VERSION_NUMBER = 1,
@@ -143,7 +146,8 @@ pub enum OpenMessageErrorSubcode {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UpdateMessageErrorSubcode {
     UNSPECIFIC = 0,
     MALFORMED_ATTRIBUTE_LIST = 1,
@@ -166,7 +170,8 @@ pub enum UpdateMessageErrorSubcode {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpFiniteStateMachineErrorSubcode {
     UNSPECIFIED = 0,
     RECEIVE_UNEXPECTED_MESSAGE_IN_OPENSENT_State = 1,
@@ -181,7 +186,8 @@ pub enum BgpFiniteStateMachineErrorSubcode {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpCeaseNotificationMessageSubcode {
     RESERVED = 0,
     MAXIMUM_NUMBER_OF_PREFIXES_REACHED = 1,
@@ -203,7 +209,8 @@ pub enum BgpCeaseNotificationMessageSubcode {
 ///
 /// *See source code for number assignment*
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpRouteRefreshMessageErrorSubcode {
     RESERVED = 0,
     INVALID_MESSAGE_LENGTH = 1,

--- a/src/models/bgp/mod.rs
+++ b/src/models/bgp/mod.rs
@@ -17,10 +17,10 @@ pub use role::*;
 use crate::models::network::*;
 use capabilities::BgpCapabilityType;
 use error::BgpError;
-use serde::Serialize;
 use std::net::Ipv4Addr;
 
-#[derive(Debug, Primitive, Copy, Clone, Serialize, PartialEq)]
+#[derive(Debug, Primitive, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpMessageType {
     OPEN = 1,
     UPDATE = 2,
@@ -29,7 +29,8 @@ pub enum BgpMessageType {
 }
 
 // https://tools.ietf.org/html/rfc4271#section-4
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpMessage {
     Open(BgpOpenMessage),
     Update(BgpUpdateMessage),
@@ -58,7 +59,8 @@ pub enum BgpMessage {
 ///  |                                                               |
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpOpenMessage {
     pub version: u8,
     pub asn: Asn,
@@ -68,14 +70,16 @@ pub struct BgpOpenMessage {
     pub opt_params: Vec<OptParam>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OptParam {
     pub param_type: u8,
     pub param_len: u16,
     pub param_value: ParamValue,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParamValue {
     Raw(Vec<u8>),
     Capability(Capability),
@@ -85,7 +89,8 @@ pub enum ParamValue {
 ///
 /// - RFC3392: <https://datatracker.ietf.org/doc/html/rfc3392>
 /// - Capability codes: <https://www.iana.org/assignments/capability-codes/capability-codes.xhtml#capability-codes-2>
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Capability {
     pub code: u8,
     pub len: u8,
@@ -93,14 +98,16 @@ pub struct Capability {
     pub capability_type: Option<BgpCapabilityType>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpUpdateMessage {
     pub withdrawn_prefixes: Vec<NetworkPrefix>,
     pub attributes: Vec<Attribute>,
     pub announced_prefixes: Vec<NetworkPrefix>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpNotificationMessage {
     pub error_code: u8,
     pub error_subcode: u8,
@@ -108,5 +115,6 @@ pub struct BgpNotificationMessage {
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BgpKeepAliveMessage {}

--- a/src/models/bgp/role.rs
+++ b/src/models/bgp/role.rs
@@ -1,10 +1,10 @@
 use num_traits::FromPrimitive;
-use serde::Serialize;
 
 /// BGP Role
 ///
 /// Defined in [RFC9234](https://www.iana.org/go/rfc9234).
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpRole {
     Provider = 0,
     RouteServer = 1,

--- a/src/models/mrt/bgp4mp.rs
+++ b/src/models/mrt/bgp4mp.rs
@@ -1,10 +1,10 @@
 //! MRT BGP4MP structs
 use crate::models::*;
-use serde::Serialize;
 use std::net::IpAddr;
 
 /// BGP states enum.
-#[derive(Debug, Primitive, Copy, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Primitive, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BgpState {
     Idle = 1,
     Connect = 2,
@@ -15,7 +15,8 @@ pub enum BgpState {
 }
 
 /// BGP4MP message types.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Bgp4Mp {
     Bgp4MpStateChange(Bgp4MpStateChange),
     Bgp4MpStateChangeAs4(Bgp4MpStateChange),
@@ -26,7 +27,8 @@ pub enum Bgp4Mp {
 }
 
 /// BGP4MP message subtypes.
-#[derive(Debug, Primitive, Copy, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Primitive, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Bgp4MpType {
     Bgp4MpStateChange = 0,
     Bgp4MpMessage = 1,
@@ -41,7 +43,8 @@ pub enum Bgp4MpType {
 }
 
 /// BGP4MP state change message.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bgp4MpStateChange {
     pub msg_type: Bgp4MpType,
     pub peer_asn: Asn,
@@ -55,7 +58,8 @@ pub struct Bgp4MpStateChange {
 }
 
 /// BGP4MP message.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bgp4MpMessage {
     pub msg_type: Bgp4MpType,
     pub peer_asn: Asn,

--- a/src/models/mrt/mod.rs
+++ b/src/models/mrt/mod.rs
@@ -4,7 +4,6 @@ pub mod bgp4mp;
 pub mod tabledump;
 
 pub use bgp4mp::*;
-use serde::Serialize;
 use std::io;
 use std::io::Write;
 pub use tabledump::*;
@@ -24,7 +23,8 @@ pub use tabledump::*;
 ///
 /// See [CommonHeader] for the content in header, and [MrtMessage] for the
 /// message format.
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MrtRecord {
     pub common_header: CommonHeader,
     pub message: MrtMessage,
@@ -70,7 +70,8 @@ pub struct MrtRecord {
 ///   `BGP4MP_ET`
 ///
 /// [header-link]: https://datatracker.ietf.org/doc/html/rfc6396#section-2
-#[derive(Debug, Copy, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommonHeader {
     pub timestamp: u32,
     pub microsecond_timestamp: Option<u32>,
@@ -98,7 +99,8 @@ impl CommonHeader {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MrtMessage {
     TableDumpMessage(TableDumpMessage),
     TableDumpV2Message(TableDumpV2Message),
@@ -127,7 +129,8 @@ pub enum MrtMessage {
 ///     48   OSPFv3
 ///     49   OSPFv3_ET
 /// ```
-#[derive(Debug, Primitive, Copy, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Primitive, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 #[repr(u16)]
 pub enum EntryType {

--- a/src/models/mrt/tabledump.rs
+++ b/src/models/mrt/tabledump.rs
@@ -1,11 +1,11 @@
 //! MRT table dump version 1 and 2 structs
 use crate::models::*;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
 /// TableDump message version 1
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableDumpMessage {
     pub view_number: u16,
     pub sequence_number: u16,
@@ -18,7 +18,8 @@ pub struct TableDumpMessage {
 }
 
 /// TableDump message version 2 enum
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TableDumpV2Message {
     PeerIndexTable(PeerIndexTable),
     RibAfiEntries(RibAfiEntries),
@@ -28,7 +29,8 @@ pub enum TableDumpV2Message {
 /// TableDump version 2 subtypes.
 ///
 /// <https://www.iana.org/assignments/mrt/mrt.xhtml#subtype-codes>
-#[derive(Debug, Primitive, Copy, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Primitive, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TableDumpV2Type {
     PeerIndexTable = 1,
     RibIpv4Unicast = 2,
@@ -72,7 +74,8 @@ pub enum TableDumpV2Type {
 ///        |         Entry Count           |  RIB Entries (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RibAfiEntries {
     pub rib_type: TableDumpV2Type,
     pub sequence_number: u32,
@@ -101,7 +104,8 @@ pub struct RibAfiEntries {
 ///        |         Entry Count           |  RIB Entries (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RibGenericEntries {
     pub sequence_number: u32,
     pub afi: Afi,
@@ -131,7 +135,8 @@ pub struct RibGenericEntries {
 ///        |                    BGP Attributes... (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RibEntry {
     pub peer_index: u16,
     pub originated_time: u32,
@@ -149,7 +154,8 @@ pub struct RibEntry {
 ///    itself and includes full MRT record headers.  The RIB entry MRT
 ///    records MUST immediately follow the PEER_INDEX_TABLE MRT record.
 /// ```
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerIndexTable {
     pub collector_bgp_id: Ipv4Addr,
     pub view_name_length: u16,
@@ -159,7 +165,8 @@ pub struct PeerIndexTable {
 }
 
 /// Peer struct.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Peer {
     pub peer_type: u8,
     pub peer_bgp_id: Ipv4Addr,

--- a/src/models/network/afi.rs
+++ b/src/models/network/afi.rs
@@ -1,9 +1,8 @@
-use serde::Serialize;
-
 /// AFI -- Address Family Identifier
 ///
 /// <https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml>
-#[derive(Debug, PartialEq, Primitive, Clone, Copy, Serialize, Eq)]
+#[derive(Debug, PartialEq, Primitive, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Afi {
     Ipv4 = 1,
     Ipv6 = 2,
@@ -12,7 +11,8 @@ pub enum Afi {
 /// SAFI -- Subsequent Address Family Identifier
 ///
 /// SAFI can be: Unicast, Multicast, or both.
-#[derive(Debug, PartialEq, Primitive, Clone, Copy, Serialize, Eq)]
+#[derive(Debug, PartialEq, Primitive, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Safi {
     Unicast = 1,
     Multicast = 2,

--- a/src/models/network/asn.rs
+++ b/src/models/network/asn.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 /// AS number length: 16 or 32 bits.
@@ -64,26 +63,32 @@ impl From<Asn> for u32 {
     }
 }
 
-impl Serialize for Asn {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u32(self.asn)
-    }
-}
-
-impl<'de> Deserialize<'de> for Asn {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        u32::deserialize(deserializer).map(Asn::from)
-    }
-}
-
 impl Display for Asn {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.asn)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for Asn {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+        {
+            serializer.serialize_u32(self.asn)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Asn {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+        {
+            u32::deserialize(deserializer).map(Asn::from)
+        }
     }
 }

--- a/src/models/network/asn.rs
+++ b/src/models/network/asn.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 /// AS number length: 16 or 32 bits.
@@ -69,6 +69,15 @@ impl Serialize for Asn {
         S: Serializer,
     {
         serializer.serialize_u32(self.asn)
+    }
+}
+
+impl<'de> Deserialize<'de> for Asn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u32::deserialize(deserializer).map(Asn::from)
     }
 }
 

--- a/src/models/network/asn.rs
+++ b/src/models/network/asn.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 
 /// AS number length: 16 or 32 bits.
-#[derive(Debug, Clone, Serialize, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AsnLength {
     Bits16,
     Bits32,

--- a/src/models/network/asn.rs
+++ b/src/models/network/asn.rs
@@ -10,6 +10,8 @@ pub enum AsnLength {
 
 /// ASN -- Autonomous System Number
 #[derive(Debug, Clone, Copy, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
 pub struct Asn {
     pub asn: u32,
     pub len: AsnLength,
@@ -66,29 +68,5 @@ impl From<Asn> for u32 {
 impl Display for Asn {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.asn)
-    }
-}
-
-#[cfg(feature = "serde")]
-mod serde_impl {
-    use super::*;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    impl Serialize for Asn {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-        {
-            serializer.serialize_u32(self.asn)
-        }
-    }
-
-    impl<'de> Deserialize<'de> for Asn {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-        {
-            u32::deserialize(deserializer).map(Asn::from)
-        }
     }
 }

--- a/src/models/network/nexthop.rs
+++ b/src/models/network/nexthop.rs
@@ -14,20 +14,10 @@ pub enum NextHopAddress {
 
 impl Display for NextHopAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                NextHopAddress::Ipv4(v) => {
-                    v.to_string()
-                }
-                NextHopAddress::Ipv6(v) => {
-                    v.to_string()
-                }
-                NextHopAddress::Ipv6LinkLocal(v1, _v2) => {
-                    v1.to_string()
-                }
-            }
-        )
+        match self {
+            NextHopAddress::Ipv4(v) => write!(f, "{}", v),
+            NextHopAddress::Ipv6(v) => write!(f, "{}", v),
+            NextHopAddress::Ipv6LinkLocal(v, _) => write!(f, "{}", v),
+        }
     }
 }

--- a/src/models/network/nexthop.rs
+++ b/src/models/network/nexthop.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// enum that represents the type of the next hop address.
 ///
 /// [NextHopAddress] is used when parsing for next hops in [Nlri](crate::models::Nlri).
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Eq)]
+#[derive(Debug, PartialEq, Copy, Clone, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NextHopAddress {
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),

--- a/src/models/network/prefix.rs
+++ b/src/models/network/prefix.rs
@@ -1,6 +1,5 @@
 use crate::models::BgpModelsError;
 use ipnet::IpNet;
-use serde::{Serialize, Serializer};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -9,15 +8,6 @@ use std::str::FromStr;
 pub struct NetworkPrefix {
     pub prefix: IpNet,
     pub path_id: u32,
-}
-
-impl Serialize for NetworkPrefix {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_str(self)
-    }
 }
 
 impl FromStr for NetworkPrefix {
@@ -38,5 +28,47 @@ impl NetworkPrefix {
 impl Display for NetworkPrefix {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.prefix)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged, deny_unknown_fields)]
+    enum SerdeNetworkPrefixRepr {
+        PlainPrefix(IpNet),
+        WithPathId {
+            prefix: IpNet,
+            path_id: u32,
+        }
+    }
+
+    impl Serialize for NetworkPrefix {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+            if serializer.is_human_readable() && self.path_id == 0 {
+                self.prefix.serialize(serializer)
+            } else {
+                SerdeNetworkPrefixRepr::WithPathId {
+                    prefix: self.prefix,
+                    path_id: self.path_id,
+                }.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NetworkPrefix {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+            match SerdeNetworkPrefixRepr::deserialize(deserializer)? {
+                SerdeNetworkPrefixRepr::PlainPrefix(prefix) => Ok(NetworkPrefix {
+                    prefix,
+                    path_id: 0,
+                }),
+                SerdeNetworkPrefixRepr::WithPathId { prefix, path_id } =>
+                    Ok(NetworkPrefix { prefix, path_id }),
+            }
+        }
     }
 }

--- a/src/models/network/prefix.rs
+++ b/src/models/network/prefix.rs
@@ -40,34 +40,38 @@ mod serde_impl {
     #[serde(untagged, deny_unknown_fields)]
     enum SerdeNetworkPrefixRepr {
         PlainPrefix(IpNet),
-        WithPathId {
-            prefix: IpNet,
-            path_id: u32,
-        }
+        WithPathId { prefix: IpNet, path_id: u32 },
     }
 
     impl Serialize for NetworkPrefix {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
             if serializer.is_human_readable() && self.path_id == 0 {
                 self.prefix.serialize(serializer)
             } else {
                 SerdeNetworkPrefixRepr::WithPathId {
                     prefix: self.prefix,
                     path_id: self.path_id,
-                }.serialize(serializer)
+                }
+                .serialize(serializer)
             }
         }
     }
 
     impl<'de> Deserialize<'de> for NetworkPrefix {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
             match SerdeNetworkPrefixRepr::deserialize(deserializer)? {
-                SerdeNetworkPrefixRepr::PlainPrefix(prefix) => Ok(NetworkPrefix {
-                    prefix,
-                    path_id: 0,
-                }),
-                SerdeNetworkPrefixRepr::WithPathId { prefix, path_id } =>
-                    Ok(NetworkPrefix { prefix, path_id }),
+                SerdeNetworkPrefixRepr::PlainPrefix(prefix) => {
+                    Ok(NetworkPrefix { prefix, path_id: 0 })
+                }
+                SerdeNetworkPrefixRepr::WithPathId { prefix, path_id } => {
+                    Ok(NetworkPrefix { prefix, path_id })
+                }
             }
         }
     }

--- a/src/models/network/prefix.rs
+++ b/src/models/network/prefix.rs
@@ -16,7 +16,7 @@ impl Serialize for NetworkPrefix {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        serializer.collect_str(self)
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,6 +10,8 @@ pub mod bmp;
 pub mod filter;
 pub mod iters;
 pub mod mrt;
+
+#[cfg(feature = "rislive")]
 pub mod rislive;
 
 pub(crate) use self::utils::*;
@@ -26,6 +28,8 @@ pub use bmp::{parse_bmp_msg, parse_openbmp_header, parse_openbmp_msg};
 pub use filter::*;
 pub use iters::*;
 pub use mrt::*;
+
+#[cfg(feature = "rislive")]
 pub use rislive::parse_ris_live_message;
 
 pub struct BgpkitParser<R> {


### PR DESCRIPTION
The primary objective of this pull request is to improve support for `serde` to allow for all `bgpkit_parser::model` types to be both `Serialize` and `Deserialize`.

In all honesty, I am not really expecting this to merge soon, but it would be really nice to have. If this is merged, I would recommend maybe documenting the `serde` feature as experimental and subject to change to give a big more freedom in changing the code layout before the serialization format is finalized.

## General Changes
 - Creation of new `serde` feature. This is to mimic how `serde` is presented in other popular crates and generally helps to slightly reduce compile times (I doubt it will have a very noticeable effect though due to the number of other dependencies that are required).
 - Creation of new `rislive` feature. Since the `rislive` module requires `serde` to function and is not used by all users, I opted to make a feature toggle for it which can depend on the `serde` feature.
 - Addition of the `--all-features` argument to the Github actions test workflow to ensure that everything is being tested.
 - Cleanup of `std::fmt::Display` implementations due to their usage by `Serialize`. In most cases, this just means removing intermediate `to_string` and `format!` calls. However, I left calls to `.join("")` alone since they seemed like more trouble than they are worth to convert with the exception of `AsPath` due to its frequent use.

## Serialization Changes
All types within `bgpkit_parser::model` (with the exception of error types) now implement **lossless** `Serialize` and `Deserialize`. This means that someone should be able to serialize then deserialize any of these types and get back the structure that they started with. Changes to serialization mostly apply to types which were serialized using their implementations of `Display`. In this case, many of these types did not serialize all of their information making it impossible to perfectly re-assemble.

### `AsPath`
For this type, there are 2 serialization formats it uses (simplified and verbose). The simplified format is preferred and more or less matches the original format for readability. However, I did switch from a string to a list to improve ease of parsing the value from other languages. The verbose format explicitly states the type and values of each segment. It only gets used when using the simplified format would lead to ambiguity. Or in other words, it gets used when the path has confederation segments or multiple adjacent sequences.
```rust
// Example data
let a = AsPath::from_segments(vec![
    AsSequence(vec![Asn::from(231), Asn::from(432)]),
    AsSet(vec![Asn::from(643), Asn::from(836)]),
    AsSequence(vec![Asn::from(352)])
]);
let b = AsPath::from_segments(vec![
    ConfedSequence(vec![Asn::from(123), Asn::from(942)]),
    AsSequence(vec![Asn::from(773)]),
    AsSequence(vec![Asn::from(382), Asn::from(293)])
]);

// JSON serializations before change
"231 432 {643,836} 352"
"123 942 773 382 293"

// JSON serializations after change
[231, 432, [643, 836], 352]
[
    { "ty": "AS_CONFED_SEQUENCE", "values": [123, 942] },
    { "ty": "AS_SEQUENCE", "values": [773] },
    { "ty": "AS_SEQUENCE", "values": [382, 293] }
]
```

### `NetworkPrefix`
This type will continue to be serialized the same way as before for human-readable data formats (such as JSON), but only so long as the `path_id` is 0. If the `path_id` is not 0, then it will be serialized as an object with prefix and path as separate fields.
```rust
// Example data
let a = NetworkPrefix {
    prefix: "10.0.1.0/24".parse().unwrap(),
    path_id: 0,
};
let b = NetworkPrefix {
    prefix: "192.168.33.0/24".parse().unwrap(),
    path_id: 2,
};

// JSON serializations before change
"10.0.1.0/24"
"192.168.33.0/24"

// JSON serializations after change
"10.0.1.0/24"
{ "prefix": "192.168.33.0/24", "path_id": 2 }
```

### `Origin` and `ElemType`
I switched these types from manual to derived versions of `Serialize`. For human readable data formats this means there is not actually any change in the output. However, most binary formats will likely choose to encode these values as integers instead of strings to save space. I doubt this will have any implications, but I thought I would include it in this list for the sake of completeness.

### `Asn`
I did not change the serialization format of `Asn` so this is the only type which **does not maintain lossless serialization**. This is due to how it does not preserve `AsnLength`. Honestly, I just didn't think that this information is worth preserving. We can already determine the `AsnLength` based on if the type it was parsed from was `AS` or `AS4`. I also imagine most (all?) users do not really care about the distinction and any that do probably do not need that information to be saved with each ASN. In fact, I would be in favor of going one step farther and simply removing the `len` field from `Asn`.

### Communities
In the case of communities, I switched it to use regular derived serialization. Their `Display` implementations should still function the same, but the serialization is now completely different. I'm not sure if this correct approach, but it seemed like the more data friendly option.
