### PR TITLE
Add support for rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.11.0", features=["lib"], optional = true }
+oneio = {version= "0.11.0", optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing
@@ -47,7 +47,7 @@ env_logger = {version="0.10", optional=true}
 clap = {version= "4.0", features=["derive"], optional=true}
 
 [features]
-default = ["parser"]
+default = ["parser", "native-tls"]
 models = [
     "num_enum",
     "num_enum/complex-expressions",
@@ -61,7 +61,6 @@ parser = [
     "env_logger",
     "log",
     "models",
-    "oneio",
     "regex",
 ]
 cli = [
@@ -80,6 +79,19 @@ rislive = [
 serde = [
     "dep:serde",
     "ipnet/serde",
+]
+native-tls = [
+    "oneio/lib",
+    "oneio/native-tls"
+]
+rustls = [
+    "oneio/rustls",
+    "oneio/remote",
+    "oneio/rustls",
+    "oneio/gz",
+    "oneio/bz",
+    "oneio/lz",
+    "oneio/json",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.11.0", optional = true }
+oneio = {version= "0.13.0", optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.13.0", optional = true }
+oneio = {version= "0.11.0", features=["lib"], optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing
@@ -56,17 +56,13 @@ models = [
     "bitflags",
 ]
 parser = [
-    "__parser_dependencies",
-    "oneio/lib",
-]
-parser-rustls = [
-    "__parser_dependencies",
-    "oneio/remote",
-    "oneio/rustls",
-    "oneio/gz",
-    "oneio/bz",
-    "oneio/lz",
-    "oneio/json",
+    "bytes",
+    "chrono",
+    "env_logger",
+    "log",
+    "models",
+    "oneio",
+    "regex",
 ]
 cli = [
     "clap",
@@ -84,16 +80,6 @@ rislive = [
 serde = [
     "dep:serde",
     "ipnet/serde",
-]
-
-# Internal use only
-__parser_dependencies = [
-    "bytes",
-    "chrono",
-    "env_logger",
-    "log",
-    "models",
-    "regex",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.11.0", features=["lib"], optional = true }
+oneio = {version= "0.13.0", optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing
@@ -56,13 +56,17 @@ models = [
     "bitflags",
 ]
 parser = [
-    "bytes",
-    "chrono",
-    "env_logger",
-    "log",
-    "models",
-    "oneio",
-    "regex",
+    "__parser_dependencies",
+    "oneio/lib",
+]
+parser-rustls = [
+    "__parser_dependencies",
+    "oneio/remote",
+    "oneio/rustls",
+    "oneio/gz",
+    "oneio/bz",
+    "oneio/lz",
+    "oneio/json",
 ]
 cli = [
     "clap",
@@ -80,6 +84,16 @@ rislive = [
 serde = [
     "dep:serde",
     "ipnet/serde",
+]
+
+# Internal use only
+__parser_dependencies = [
+    "bytes",
+    "chrono",
+    "env_logger",
+    "log",
+    "models",
+    "regex",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.13.0", default-features = false, optional = true }
+oneio = {version= "0.13.1", default-features = false, optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,12 @@ native-tls = [
     "oneio/native-tls"
 ]
 rustls = [
-    "oneio/rustls",
     "oneio/remote",
-    "oneio/rustls",
     "oneio/gz",
     "oneio/bz",
     "oneio/lz",
     "oneio/json",
+    "oneio/rustls",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,7 @@ serde = [
     "ipnet/serde",
 ]
 native-tls = [
-    "oneio/lib",
-    "oneio/native-tls"
+    "oneio/lib-native-tls",
 ]
 rustls = [
     "oneio/remote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,7 @@ native-tls = [
     "oneio/lib-native-tls",
 ]
 rustls = [
-    "oneio/remote",
-    "oneio/gz",
-    "oneio/bz",
-    "oneio/lz",
-    "oneio/json",
-    "oneio/rustls",
+    "oneio/lib-rustls",
 ]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.13.0", optional = true }
+oneio = {version= "0.13.0", default-features = false, optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,14 +368,14 @@ We support normal communities, extended communities, and large communities.
 #![allow(clippy::new_without_default)]
 #![allow(clippy::needless_range_loop)]
 
-#[cfg(feature = "parser")]
+#[cfg(any(feature = "parser", feature = "parser-rustls"))]
 pub mod error;
 #[cfg(feature = "models")]
 pub mod models;
-#[cfg(feature = "parser")]
+#[cfg(any(feature = "parser", feature = "parser-rustls"))]
 pub mod parser;
 
 #[cfg(feature = "models")]
 pub use models::BgpElem;
-#[cfg(feature = "parser")]
+#[cfg(any(feature = "parser", feature = "parser-rustls"))]
 pub use parser::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,14 +368,14 @@ We support normal communities, extended communities, and large communities.
 #![allow(clippy::new_without_default)]
 #![allow(clippy::needless_range_loop)]
 
-#[cfg(any(feature = "parser", feature = "parser-rustls"))]
+#[cfg(feature = "parser")]
 pub mod error;
 #[cfg(feature = "models")]
 pub mod models;
-#[cfg(any(feature = "parser", feature = "parser-rustls"))]
+#[cfg(feature = "parser")]
 pub mod parser;
 
 #[cfg(feature = "models")]
 pub use models::BgpElem;
-#[cfg(any(feature = "parser", feature = "parser-rustls"))]
+#[cfg(feature = "parser")]
 pub use parser::*;


### PR DESCRIPTION
This is the final pull request in a series to add support for using rustls as the underlying TLS library for bgpkit-parser's dependencies. The two other related pull requests were:

- https://github.com/bgpkit/oneio/pull/21
- https://github.com/bgpkit/bgpkit-commons/pull/2 (not a dependency, but similar in nature)

This pull request introduces a new feature flag known as `parser-rustls` that enables oneio's `rustls` feature flag. I'm not sure this is the best option, and would love feedback on this approach. Alternatively, we can also explore adding two new feature flags: `native-tls` and `rustls`, similar to what was done in https://github.com/bgpkit/oneio/pull/21, but that feels like more of a breaking change, and this is a far more popular crate and would require users to explicitly opt into both flags when they want to use `parser`: `features = ["parser", "native-tls"]` or `features = ["parser", "rustls"]`.

Happy to make updates based on the preferred approach, and thank you for considering this PR!