### PR TITLE
add back `to_u32_vec` function

### DIFF
--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -651,6 +651,13 @@ impl AsPath {
             _ => None,
         }
     }
+
+    pub fn to_u32_vec(&self) -> Option<Vec<u32>> {
+        match self.segments.last() {
+            Some(AsPathSegment::AsSequence(v)) => Some(v.iter().map(|asn| (*asn).into()).collect()),
+            _ => None,
+        }
+    }
 }
 
 /// Iterates over all route variations the given `AsPath` represents.

--- a/src/models/network/asn.rs
+++ b/src/models/network/asn.rs
@@ -124,6 +124,13 @@ impl From<Asn> for u32 {
     }
 }
 
+impl From<&Asn> for u32 {
+    #[inline]
+    fn from(value: &Asn) -> Self {
+        value.asn
+    }
+}
+
 impl Display for Asn {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.asn)


### PR DESCRIPTION
This function is used in other places, this PR would avoid breaking changes.