### PR TITLE
Support Adj-RIB-out for BMP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = {version="2.3.3", features = ["serde"], optional = true}
 bytes = {version = "1.4.0", optional = true}
 hex= {version = "0.4.3", optional = true} # bmp/openbmp parsing
 log= {version = "0.4", optional = true }
-oneio = {version= "0.13.1", default-features = false, optional = true }
+oneio = {version= "0.13.2", default-features = false, optional = true }
 regex = {version = "1", optional = true} # used in parser filter
 chrono = {version="0.4.24", optional = true} # parser filter
 serde_json = {version = "1.0", optional = true } # RIS Live parsing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BGPKIT Parser
 
-*This readme is generated from the library's doc comments using [cargo-readme](https://github.com/livioribeiro/cargo-readme). Please refer to the Rust docs website for the full documentation: [latest stable](https://docs.rs/bgpkit-parser/latest/bgpkit_parser/); [bleeding-edge](https://docs.rs/bgpkit-parser/0.10.0-alpha.1/bgpkit_parser/).*
+*This readme is generated from the library's doc comments using [cargo-readme](https://github.com/livioribeiro/cargo-readme). Please refer to the Rust docs website for the full documentation: [latest stable](https://docs.rs/bgpkit-parser/latest/bgpkit_parser/); [bleeding-edge](https://docs.rs/bgpkit-parser/0.10.0-alpha.2/bgpkit_parser/).*
 
 [![Rust](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml/badge.svg)](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/bgpkit-parser)](https://crates.io/crates/bgpkit-parser)
@@ -343,7 +343,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 ### BMP
 
 - [X] [RFC 7854](https://datatracker.ietf.org/doc/html/rfc7854): BGP Monitoring Protocol (BMP)
-- [ ] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
+- [X] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
 
 ### Communities
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 ## BMP
 
 - [X] [RFC 7854](https://datatracker.ietf.org/doc/html/rfc7854): BGP Monitoring Protocol (BMP)
-- [ ] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
+- [X] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
 
 ## Communities
 

--- a/src/models/bgp/mod.rs
+++ b/src/models/bgp/mod.rs
@@ -16,7 +16,6 @@ pub use role::*;
 
 use crate::models::network::*;
 use capabilities::BgpCapabilityType;
-use error::BgpError;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::net::Ipv4Addr;
 

--- a/src/parser/bmp/messages/stats_report.rs
+++ b/src/parser/bmp/messages/stats_report.rs
@@ -8,6 +8,9 @@ pub struct StatsReport {
     pub counters: Vec<StatCounter>,
 }
 
+/// Statistics count values
+///
+/// Types of BMP statistics are listed here: <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#statistics-types>
 #[derive(Debug)]
 pub struct StatCounter {
     pub stat_type: u16,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,10 +16,8 @@ pub mod rislive;
 
 pub(crate) use self::utils::*;
 pub(crate) use bgp::attributes::AttributeParser;
-pub(crate) use mrt::{parse_bgp4mp, parse_table_dump_message, parse_table_dump_v2_message};
 
 use crate::models::MrtRecord;
-use filter::Filter;
 pub use mrt::mrt_elem::Elementor;
 use oneio::{get_cache_reader, get_reader};
 


### PR DESCRIPTION
Add support for [RFC 8671](https://www.rfc-editor.org/rfc/rfc8671#section-4), which allows BMP to stream Adj-RIB-out messages.

This addresses #130.