### PR TITLE
add support for RFC 9069

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,7 @@ env:
 
 jobs:
   build:
-
     runs-on: self-hosted
-
     steps:
     - uses: actions/checkout@v2
 
@@ -25,3 +23,6 @@ jobs:
 
     - name: Run format check
       run: cargo fmt --check
+
+    - name: Run cargo-readme check
+      run: cargo readme > TMP_README.md && diff -b TMP_README.md README.md > /dev/null

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,4 @@ jobs:
       run: cargo fmt --check
 
     - name: Run cargo-readme check
-      run: cargo readme > TMP_README.md && diff -b TMP_README.md README.md > /dev/null
+      run: cargo readme > TMP_README.md && diff -b TMP_README.md README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BGPKIT Parser
 
-*This readme is generated from the library's doc comments using [cargo-readme](https://github.com/livioribeiro/cargo-readme). Please refer to the Rust docs website for the full documentation: [latest stable](https://docs.rs/bgpkit-parser/latest/bgpkit_parser/); [bleeding-edge](https://docs.rs/bgpkit-parser/0.10.0-alpha.2/bgpkit_parser/).*
+*This readme is generated from the library's doc comments using [cargo-readme](https://github.com/livioribeiro/cargo-readme). Please refer to the Rust docs website for the full documentation: [latest stable](https://docs.rs/bgpkit-parser/latest/bgpkit_parser/); [bleeding-edge](https://docs.rs/bgpkit-parser/0.10.0-alpha.3/bgpkit_parser/).*
 
 [![Rust](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml/badge.svg)](https://github.com/bgpkit/bgpkit-parser/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/bgpkit-parser)](https://crates.io/crates/bgpkit-parser)
@@ -344,6 +344,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 
 - [X] [RFC 7854](https://datatracker.ietf.org/doc/html/rfc7854): BGP Monitoring Protocol (BMP)
 - [X] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
+- [X] [RFC 9069](https://datatracker.ietf.org/doc/html/rfc9069): Support for Local RIB in the BGP Monitoring Protocol (BMP)
 
 ### Communities
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 
 - [X] [RFC 7854](https://datatracker.ietf.org/doc/html/rfc7854): BGP Monitoring Protocol (BMP)
 - [X] [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671): Support for Adj-RIB-Out in the BGP Monitoring Protocol (BMP)
+- [X] [RFC 9069](https://datatracker.ietf.org/doc/html/rfc9069): Support for Local RIB in the BGP Monitoring Protocol (BMP)
 
 ## Communities
 

--- a/src/parser/bmp/mod.rs
+++ b/src/parser/bmp/mod.rs
@@ -40,7 +40,7 @@ pub fn parse_bmp_msg(data: &mut Bytes) -> Result<BmpMessage, ParserBmpError> {
     match &common_header.msg_type {
         BmpMsgType::RouteMonitoring => {
             let per_peer_header = parse_per_peer_header(data)?;
-            let msg = parse_route_monitoring(data, &per_peer_header.peer_flags.asn_length())?;
+            let msg = parse_route_monitoring(data, &per_peer_header.asn_length())?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),
@@ -49,7 +49,7 @@ pub fn parse_bmp_msg(data: &mut Bytes) -> Result<BmpMessage, ParserBmpError> {
         }
         BmpMsgType::RouteMirroringMessage => {
             let per_peer_header = parse_per_peer_header(data)?;
-            let msg = parse_route_mirroring(data, &per_peer_header.peer_flags.asn_length())?;
+            let msg = parse_route_mirroring(data, &per_peer_header.asn_length())?;
             Ok(BmpMessage {
                 common_header,
                 per_peer_header: Some(per_peer_header),


### PR DESCRIPTION
RFC9069: Support for Local RIB in the BGP Monitoring Protocol (BMP)

This PR resolves issue #132 