### PR TITLE
Implement BMP listener

### DIFF
--- a/examples/bmp_listener.rs
+++ b/examples/bmp_listener.rs
@@ -1,0 +1,60 @@
+use bgpkit_parser::bmp::messages::MessageBody::RouteMirroring;
+use bgpkit_parser::parse_bmp_msg;
+use bytes::{Buf, Bytes};
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+fn handle_client(mut stream: TcpStream) {
+    let mut buffer = [0; 1024];
+
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(bytes_read) => {
+                if bytes_read == 0 {
+                    println!("Client disconnected.");
+                    break;
+                }
+
+                // Convert the received data to a hexadecimal string
+                let hex_string = buffer[..bytes_read]
+                    .iter()
+                    .map(|b| format!("{:02X}", b))
+                    .collect::<Vec<String>>()
+                    .join(" ");
+                println!("Received data (hex): {}", hex_string);
+
+                let mut data = Bytes::from(buffer[..bytes_read].to_vec());
+                while data.remaining() > 0 {
+                    let msg = parse_bmp_msg(&mut data).unwrap();
+                    dbg!(msg);
+                }
+            }
+            Err(e) => {
+                eprintln!("Error reading from socket: {}", e);
+                break;
+            }
+        }
+    }
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:11019").expect("Failed to bind to address");
+
+    println!("Server listening on 0.0.0.0:11019...");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                println!("Accepted a new connection");
+                let child_thread = thread::spawn(move || {
+                    handle_client(stream);
+                });
+                child_thread.join().expect("Thread panicked");
+            }
+            Err(e) => {
+                eprintln!("Error accepting connection: {}", e);
+            }
+        }
+    }
+}

--- a/src/parser/bmp/messages/headers.rs
+++ b/src/parser/bmp/messages/headers.rs
@@ -36,6 +36,7 @@ pub enum BmpMsgType {
 
 /// BMP Common Header
 ///
+/// https://www.rfc-editor.org/rfc/rfc7854#section-4.1
 /// ```text
 ///       0                   1                   2                   3
 ///       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1

--- a/src/parser/bmp/messages/initiation_message.rs
+++ b/src/parser/bmp/messages/initiation_message.rs
@@ -27,6 +27,9 @@ pub enum InitiationTlvType {
     SysName = 2,
 }
 
+/// Parse BMP initiation message
+///
+/// https://www.rfc-editor.org/rfc/rfc7854#section-4.3
 pub fn parse_initiation_message(data: &mut Bytes) -> Result<InitiationMessage, ParserBmpError> {
     let mut tlvs = vec![];
 

--- a/src/parser/bmp/messages/route_mirroring.rs
+++ b/src/parser/bmp/messages/route_mirroring.rs
@@ -1,5 +1,5 @@
+use crate::bgp::parse_bgp_message;
 use crate::models::*;
-use crate::parser::bgp::messages::parse_bgp_update_message;
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::ReadUtils;
 use bytes::{Buf, Bytes};
@@ -19,7 +19,7 @@ pub struct RouteMirroringTlv {
 
 #[derive(Debug)]
 pub enum RouteMirroringValue {
-    BgpMessage(BgpUpdateMessage),
+    BgpMessage(BgpMessage),
     Information(RouteMirroringInfo),
 }
 
@@ -39,8 +39,8 @@ pub fn parse_route_mirroring(
         match data.read_u16()? {
             0 => {
                 let info_len = data.read_u16()?;
-                let bytes = data.split_to(info_len as usize);
-                let value = parse_bgp_update_message(bytes, false, asn_len)?;
+                let mut bytes = data.split_to(info_len as usize);
+                let value = parse_bgp_message(&mut bytes, false, asn_len)?;
                 tlvs.push(RouteMirroringTlv {
                     info_len,
                     value: RouteMirroringValue::BgpMessage(value),

--- a/src/parser/bmp/messages/stats_report.rs
+++ b/src/parser/bmp/messages/stats_report.rs
@@ -1,6 +1,7 @@
 use crate::parser::bmp::error::ParserBmpError;
 use crate::parser::ReadUtils;
 use bytes::Bytes;
+use num_enum::{FromPrimitive, IntoPrimitive};
 
 #[derive(Debug)]
 pub struct StatsReport {
@@ -9,13 +10,39 @@ pub struct StatsReport {
 }
 
 /// Statistics count values
-///
-/// Types of BMP statistics are listed here: <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#statistics-types>
 #[derive(Debug)]
 pub struct StatCounter {
-    pub stat_type: u16,
+    pub stat_type: StatType,
     pub stat_len: u16,
     pub stat_data: StatsData,
+}
+
+/// Stats counter types enum
+///
+/// Types of BMP statistics are listed here: <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#statistics-types>
+#[derive(Debug, FromPrimitive, IntoPrimitive)]
+#[repr(u16)]
+pub enum StatType {
+    PrefixesRejectedByInboundPolicy = 0,
+    DuplicatePrefixAdvertisements = 1,
+    DuplicateWithdrawnPrefixes = 2,
+    UpdatesInvalidatedDueToClusterListLoop = 3,
+    UpdatesInvalidatedDueToASPathLoop = 4,
+    UpdatesInvalidatedDueToOriginatorId = 5,
+    UpdatesInvalidatedDueToASConfedLoop = 6,
+    RoutesInAdjRibsIn = 7,
+    RoutesInLocRib = 8,
+    RoutesInPerAfiSafiAdjRibIn = 9,
+    RoutesInPerAfiSafiLocRib = 10,
+    UpdatesSubjectedToTreatAsWithdraw = 11,
+    PrefixesSubjectedToTreatAsWithdraw = 12,
+    DuplicateUpdateMessagesReceived = 13,
+    RoutesInPrePolicyAdjRibOut = 14,
+    RoutesInPostPolicyAdjRibOut = 15,
+    RoutesInPerAfiSafiPrePolicyAdjRibOut = 16,
+    RoutesInPerAfiSafiPostPolicyAdjRibOut = 17,
+    #[num_enum(catch_all)]
+    Other(u16) = 65535,
 }
 
 #[derive(Debug)]
@@ -28,7 +55,7 @@ pub fn parse_stats_report(data: &mut Bytes) -> Result<StatsReport, ParserBmpErro
     let stats_count = data.read_u32()?;
     let mut counters = vec![];
     for _ in 0..stats_count {
-        let stat_type = data.read_u16()?;
+        let stat_type = StatType::from(data.read_u16()?);
         let stat_len = data.read_u16()?;
         let stat_data = match stat_len {
             4 => StatsData::Counter(data.read_u32()?),


### PR DESCRIPTION
Implement a BMP listener example where it initiates a TCP listener that continuously listens to the incoming BMP messages and displays the message content.

This PR also fixes the extended-length BGP open messages parser.