### PR TITLE
fix end-of-rib detection for empty nlri object

### DIFF
--- a/examples/bmp_listener.rs
+++ b/examples/bmp_listener.rs
@@ -1,3 +1,4 @@
+use bgpkit_parser::bmp::messages::MessageBody;
 use bgpkit_parser::parse_bmp_msg;
 use bytes::{Buf, Bytes};
 use std::io::Read;
@@ -26,6 +27,11 @@ fn handle_client(mut stream: TcpStream) {
                 let mut data = Bytes::from(buffer[..bytes_read].to_vec());
                 while data.remaining() > 0 {
                     let msg = parse_bmp_msg(&mut data).unwrap();
+                    if let MessageBody::RouteMonitoring(mon_msg) = &msg.message_body {
+                        if mon_msg.is_end_of_rib() {
+                            dbg!("end of RIB");
+                        }
+                    }
                     dbg!(msg);
                 }
             }

--- a/src/models/bgp/attributes/mod.rs
+++ b/src/models/bgp/attributes/mod.rs
@@ -236,14 +236,14 @@ impl Attributes {
         })
     }
 
-    pub fn get_reachable(&self) -> Option<&Nlri> {
+    pub fn get_reachable_nlri(&self) -> Option<&Nlri> {
         self.inner.iter().find_map(|x| match &x.value {
             AttributeValue::MpReachNlri(x) => Some(x),
             _ => None,
         })
     }
 
-    pub fn get_unreachable(&self) -> Option<&Nlri> {
+    pub fn get_unreachable_nlri(&self) -> Option<&Nlri> {
         self.inner.iter().find_map(|x| match &x.value {
             AttributeValue::MpUnreachNlri(x) => Some(x),
             _ => None,

--- a/src/parser/bmp/messages/route_monitoring.rs
+++ b/src/parser/bmp/messages/route_monitoring.rs
@@ -12,9 +12,44 @@ pub fn parse_route_monitoring(
     data: &mut Bytes,
     asn_len: &AsnLength,
 ) -> Result<RouteMonitoring, ParserBmpError> {
-    // let bgp_update = parse_bgp_update_message(reader, false, afi, asn_len, total_len)?;
     let bgp_update = parse_bgp_message(data, false, asn_len)?;
     Ok(RouteMonitoring {
         bgp_message: bgp_update,
     })
+}
+
+impl RouteMonitoring {
+    /// Check if the BMP route-monitoring message is an End-of-RIB marker.
+    pub fn is_end_of_rib(&self) -> bool {
+        if let BgpMessage::Update(u) = &self.bgp_message {
+            u.is_end_of_rib()
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_end_of_rib() {
+        let msg = BgpUpdateMessage {
+            withdrawn_prefixes: vec![],
+            attributes: Attributes::default(),
+            announced_prefixes: vec![],
+        };
+        assert!(msg.is_end_of_rib());
+
+        let mon_msg = RouteMonitoring {
+            bgp_message: BgpMessage::Update(msg),
+        };
+        assert!(mon_msg.is_end_of_rib());
+
+        let mon_msg = RouteMonitoring {
+            bgp_message: BgpMessage::KeepAlive,
+        };
+        assert!(!mon_msg.is_end_of_rib());
+    }
 }


### PR DESCRIPTION
Properly detect end-of-RIB marker for messages with NLRI objects that contains empty `prefixes` field.