### PR TITLE
Replace deprecated crate, add `cargo audit` to CI

### DIFF
--- a/.github/workflows/audit_on_change.yml
+++ b/.github/workflows/audit_on_change.yml
@@ -1,0 +1,21 @@
+name: Security audit
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit_scheduled.yml
+++ b/.github/workflows/audit_scheduled.yml
@@ -1,0 +1,12 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * 6' # Run every Saturday at 00:00
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = { version = "1.0", optional = true } # RIS Live parsing
 ####################
 # CLI dependencies #
 ####################
-env_logger = { version = "0.10", optional = true }
+env_logger = { version = "0.11", optional = true }
 clap = { version = "4.0", features = ["derive"], optional = true }
 
 [features]
@@ -105,10 +105,10 @@ rayon = "1.5.1"
 bzip2 = "0.4"
 flate2 = "1.0.25"
 md5 = "0.7.0"
-which = "5"
+which = "6"
 serde_json = "1.0"
 hex = "0.4.3"
-tempdir = "0.3"
+tempfile = "3"
 ctrlc = "3.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -61,7 +61,7 @@ mod tests {
         let input_records: Vec<MrtRecord> =
             BgpkitParser::new(url).unwrap().into_record_iter().collect();
 
-        let dir = tempdir::TempDir::new("test_encode_table_dump_v1").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
         let tempfile = dir
             .path()
             .join("test_encode_table_dump_v1.mrt")


### PR DESCRIPTION
### Highlights

* Remove deprecated crate `tempdir`, replace it with `temfile`.
  * `tempdir` is only used in one test for encoding, not other places
* Add `cargo audit` checks for changes and on weekly schedule.

This resolves issue #152.