### PR TITLE
add `ip_version` filter

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -62,6 +62,14 @@ struct Filters {
     #[clap(short = 'S', long)]
     include_sub: bool,
 
+    /// Filter by IPv4 only
+    #[clap(short = '4', long)]
+    ipv4_only: bool,
+
+    /// Filter by IPv6 only
+    #[clap(short = '6', long)]
+    ipv6_only: bool,
+
     /// Filter by peer IP address
     #[clap(short = 'j', long)]
     peer_ip: Vec<IpAddr>,
@@ -145,6 +153,22 @@ fn main() {
     }
     if let Some(v) = opts.filters.end_ts {
         parser = parser.add_filter("end_ts", v.to_string().as_str()).unwrap();
+    }
+
+    match (opts.filters.ipv4_only, opts.filters.ipv6_only) {
+        (true, true) => {
+            eprintln!("Error: --ipv4-only and --ipv6-only cannot be used together");
+            std::process::exit(1);
+        }
+        (false, false) => {
+            // no filters on IP version, skip
+        }
+        (true, false) => {
+            parser = parser.add_filter("ip_version", "ipv4").unwrap();
+        }
+        (false, true) => {
+            parser = parser.add_filter("ip_version", "ipv6").unwrap();
+        }
     }
 
     match (opts.elems_count, opts.records_count) {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -102,12 +102,12 @@ fn main() {
 
     let file_path = opts.file_path.to_str().unwrap();
 
-    let mut parser = match {
-        match opts.cache_dir {
-            None => BgpkitParser::new(file_path),
-            Some(c) => BgpkitParser::new_cached(file_path, c.to_str().unwrap()),
-        }
-    } {
+    let parser_opt = match opts.cache_dir {
+        None => BgpkitParser::new(file_path),
+        Some(c) => BgpkitParser::new_cached(file_path, c.to_str().unwrap()),
+    };
+
+    let mut parser = match parser_opt {
         Ok(p) => p,
         Err(err) => {
             eprintln!("{}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,9 +241,7 @@ drop(mrt_writer);
 
 You can install the compiled `bgpkit-parser` CLI binaries with the following methods:
 - **Homebrew** (macOS): `brew install bgpkit/tap/bgpkit-parser`
-- [**Cargo binstall**](binstall): `cargo binstall bgpkit-parser`
-
-[binstall]: https://github.com/cargo-bins/cargo-binstall
+- [**Cargo binstall**](https://github.com/cargo-bins/cargo-binstall): `cargo binstall bgpkit-parser`
 
 ### From source
 
@@ -277,6 +275,8 @@ Options:
   -r, --records-count            Count MRT records
   -o, --origin-asn <ORIGIN_ASN>  Filter by origin AS Number
   -p, --prefix <PREFIX>          Filter by network prefix
+  -4, --ipv4-only                Filter by IPv4 only
+  -6, --ipv6-only                Filter by IPv6 only
   -s, --include-super            Include super-prefix when filtering
   -S, --include-sub              Include sub-prefix when filtering
   -j, --peer-ip <PEER_IP>        Filter by peer IP address

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -102,7 +102,7 @@ pub enum PrefixMatchType {
 
 fn parse_time_str(time_str: &str) -> Option<chrono::NaiveDateTime> {
     if let Ok(t) = time_str.parse::<f64>() {
-        return chrono::NaiveDateTime::from_timestamp_opt(t as i64, 0);
+        return chrono::DateTime::from_timestamp(t as i64, 0).map(|t| t.naive_utc());
     }
     if let Ok(t) = chrono::DateTime::parse_from_rfc3339(time_str) {
         return Some(t.naive_utc());
@@ -186,14 +186,14 @@ impl Filter {
                 ))),
             },
             "ts_start" | "start_ts" => match parse_time_str(filter_value) {
-                Some(t) => Ok(Filter::TsStart(t.timestamp() as f64)),
+                Some(t) => Ok(Filter::TsStart(t.and_utc().timestamp() as f64)),
                 None => Err(FilterError(format!(
                     "cannot parse TsStart filter from {}",
                     filter_value
                 ))),
             },
             "ts_end" | "end_ts" => match parse_time_str(filter_value) {
-                Some(t) => Ok(Filter::TsEnd(t.timestamp() as f64)),
+                Some(t) => Ok(Filter::TsEnd(t.and_utc().timestamp() as f64)),
                 None => Err(FilterError(format!(
                     "cannot parse TsEnd filter from {}",
                     filter_value

--- a/src/parser/filter.rs
+++ b/src/parser/filter.rs
@@ -406,6 +406,9 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_errors() {}
+
+    #[test]
     fn test_parsing_time_str() {
         let ts = chrono::NaiveDateTime::from_str("2021-11-20T19:49:58").unwrap();
         assert_eq!(parse_time_str("1637437798"), Some(ts));
@@ -506,6 +509,30 @@ mod tests {
                 PrefixMatchType::Exact
             )
         );
+        let filter = Filter::new("prefix_super", "192.168.1.0/24").unwrap();
+        assert_eq!(
+            filter,
+            Filter::Prefix(
+                IpNet::from_str("192.168.1.0/24").unwrap(),
+                PrefixMatchType::IncludeSuper
+            )
+        );
+        let filter = Filter::new("prefix_sub", "192.168.1.0/24").unwrap();
+        assert_eq!(
+            filter,
+            Filter::Prefix(
+                IpNet::from_str("192.168.1.0/24").unwrap(),
+                PrefixMatchType::IncludeSub
+            )
+        );
+        let filter = Filter::new("prefix_super_sub", "192.168.1.0/24").unwrap();
+        assert_eq!(
+            filter,
+            Filter::Prefix(
+                IpNet::from_str("192.168.1.0/24").unwrap(),
+                PrefixMatchType::IncludeSuperSub
+            )
+        );
 
         let filter = Filter::new("peer_ip", "192.168.1.1").unwrap();
         assert_eq!(
@@ -527,6 +554,20 @@ mod tests {
 
         let filter = Filter::new("as_path", r" ?174 1916 52888$").unwrap();
         assert_eq!(filter, Filter::AsPath(r" ?174 1916 52888$".to_string()));
+
+        assert!(Filter::new("origin_asn", "not a number").is_err());
+        assert!(Filter::new("peer_asn", "not a number").is_err());
+        assert!(Filter::new("ts_start", "not a number").is_err());
+        assert!(Filter::new("ts_end", "not a number").is_err());
+        assert!(Filter::new("prefix", "not a prefix").is_err());
+        assert!(Filter::new("prefix_super", "not a prefix").is_err());
+        assert!(Filter::new("prefix_sub", "not a prefix").is_err());
+        assert!(Filter::new("peer_ip", "not a IP").is_err());
+        assert!(Filter::new("peer_ips", "not,a,IP").is_err());
+        assert!(Filter::new("type", "not a type").is_err());
+        assert!(Filter::new("as_path", "[abc").is_err());
+        assert!(Filter::new("ip_version", "5").is_err());
+        assert!(Filter::new("unknown_filter", "some_value").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Added a new `ip_version` filter type that allows library and CLI users to filter messages based on IP version.

### For Library Use

For library users, when calling `add_filter` on a `BgpkitParser` instance, a new type/value tuple and can be used now:
* filter type: `ip_version`
* filter value: `ipv4` or `ipv6`

Example:
```rust
parser = parser.add_filter("ip_version", "ipv4").unwrap();
// or this
parser = parser.add_filter("ip_version", "ipv6").unwrap();
```

*Note*: currently, multiple filters are applied with "AND" logic, and thus adding both `ipv4` and `ipv6` filters will render the parser pretty much useless as no messages will match both IPv4 and IPv6.

### For CLI Use

`bgpkit-parser` CLI users can now use `-4`/`--ipv4` or `-6`/`--ipv6` to filter by IP address family.

Example:

```
mingwei@terrier bgpkit-parser % cargo run --release --features cli -- https://data.bgpkit.com/mirror/riperis/rrc00/2024.02/updates.20240201.0000.gz -4 | head   
   Compiling bgpkit-parser v0.10.1 (/Users/mingwei/Warehouse/BGPKIT/bgpkit-git/bgpkit-parser)
    Finished release [optimized] target(s) in 1.20s
     Running `target/release/bgpkit-parser 'https://data.bgpkit.com/mirror/riperis/rrc00/2024.02/updates.20240201.0000.gz' -4`
A|1706745600|12.0.1.63|7018|195.177.202.0/23|7018 1299 31027 2116 1770|IGP|12.0.1.63|0|0|7018:5000 7018:39220|false||
A|1706745600|12.0.1.63|7018|147.112.0.0/16|7018 1299 31027 2116 1770|IGP|12.0.1.63|0|0|7018:5000 7018:39220|false||
A|1706745600|45.134.89.1|34927|205.164.87.0/24|34927 56655 6939 6762 264409 61884 264275|IGP|45.134.89.1|0|0|56655:2100|false||
A|1706745600|203.123.48.6|37989|36.255.200.0/24|37989 18106 6939 3356 55644 134927 134927 134927 134927 134927|IGP|203.123.48.6|0|0|6939:2000|false|134927|10.160.26.235
A|1706745600|2.56.11.1|34854|195.177.202.0/23|34854 1299 3356 2116 1770|IGP|2.56.11.1|0|0|1299:20000 34854:3001|false||
A|1706745600|5.255.90.109|202365|200.51.171.0/24|202365 50673 6453 12956 22927|IGP|5.255.90.109|0|0|6453:86 6453:2000 6453:2300 6453:2302 50673:1000|false||
A|1706745600|45.14.68.69|206499|103.140.43.0/24|206499 50629 45899 135980|IGP|45.14.68.69|0|0|45899:3100 45899:3171 45899:3999 50629:150 50629:200 50629:401 50629:1000 50629:10001 50629:10105 50629:10210 65101:1082 65102:1000 65103:276 65104:150 lg:6695:1000:1 lg:206499:206499:50629|false||
A|1706745600|45.14.68.69|206499|103.140.42.0/24|206499 50629 45899 135980|IGP|45.14.68.69|0|0|45899:3100 45899:3171 45899:3999 50629:150 50629:200 50629:401 50629:1000 50629:10001 50629:10105 50629:10210 65101:1082 65102:1000 65103:276 65104:150 lg:6695:1000:1 lg:206499:206499:50629|false||
A|1706745600|45.61.0.85|22652|103.194.188.0/22|22652 3257 3491 45899 135963|IGP|45.61.0.85|0|0|3257:8770 3257:30350 3257:50002 3257:51200 3257:51204|false||
A|1706745600|45.134.89.1|34927|205.164.87.0/24|34927 56655 3356 4230 264275 264275 264275 264275|IGP|45.134.89.1|0|0|3356:3 3356:22 3356:100 3356:123 3356:575 3356:903 3356:2056 4230:21 4230:30 4230:611 4230:6121 56655:2100|false||

mingwei@terrier bgpkit-parser % cargo run --release --features cli -- https://data.bgpkit.com/mirror/riperis/rrc00/2024.02/updates.20240201.0000.gz -6 | head
    Finished release [optimized] target(s) in 0.07s
     Running `target/release/bgpkit-parser 'https://data.bgpkit.com/mirror/riperis/rrc00/2024.02/updates.20240201.0000.gz' -6`
A|1706745600|193.0.0.56|3333|2a01:9e00:4d0e::/48|3333 1103 20562 41495|IGP||0|0|20562:30 20562:3044 20562:4420 20562:65000 20562:65028|false||
A|1706745600|2001:67c:21ec:5000:5800:ff:fe7e:6ded|56662|2607:ff00:b00::/40|56662 137409 12189 400672|IGP||0|0|56662:64001 lg:6695:1000:1 lg:7578:0:1000 lg:7578:0:1200 lg:7578:0:3000 lg:7578:500:1 lg:7578:900:8 ecas2:0:2:7578:0000000A ecas2:0:2:7578:00000063 ecas2:0:2:7578:000003E7 ecas2:0:3:7578:00000384|false||
A|1706745600|2405:fc00::6|37989|2804:28d4:c000::/34|37989 6939 3356 28343 262607 263983|IGP||0|0||false||
A|1706745600|2405:fc00::6|37989|2804:28d4:8000::/34|37989 6939 3356 28343 262607 263983|IGP||0|0||false||
A|1706745600|2607:fad8::1:9|22652|2a0c:e643:aee3::/48|22652 1299 9002 917 213316|IGP||0|0|1299:430 1299:4000 1299:25000 1299:25002 1299:25100|false||
A|1706745600|2a03:94e0:ffff:185:181:60:0:126|207564|2804:28d4:c000::/34|207564 6939 6762 28343 262607 263983|IGP||0|0|lg:207564:1:578 lg:207564:2:150 lg:207564:3:4|false||
A|1706745600|2a03:94e0:ffff:185:181:60:0:126|207564|2804:28d4:8000::/34|207564 6939 6762 28343 262607 263983|IGP||0|0|lg:207564:1:578 lg:207564:2:150 lg:207564:3:4|false||
A|1706745600|2a09:4c0:300:c232::5ee8|61218|2804:28d4:c000::/34|61218 6939 6762 28343 262607 263983|IGP||0|0||false||
A|1706745600|2a09:4c0:300:c232::5ee8|61218|2804:28d4:8000::/34|61218 6939 6762 28343 262607 263983|IGP||0|0||false||
A|1706745600|2a0c:9a40:1038::1|34927|2804:28d4:c000::/34|34927 34927 6939 6762 28343 262607 263983|IGP||0|0|34927:610 34927:613|false||
```

### Related issues

This addresses issue #154.