### PR TITLE
Better BMP support

### DIFF
--- a/src/encoder/rib_encoder.rs
+++ b/src/encoder/rib_encoder.rs
@@ -152,8 +152,7 @@ mod tests {
 
         let mut cursor = Cursor::new(bytes.clone());
         while cursor.has_remaining() {
-            let parsed = parse_mrt_record(&mut cursor).unwrap();
-            dbg!(&parsed);
+            let _parsed = parse_mrt_record(&mut cursor).unwrap();
         }
 
         // v6
@@ -168,8 +167,7 @@ mod tests {
 
         let mut cursor = Cursor::new(bytes.clone());
         while cursor.has_remaining() {
-            let parsed = parse_mrt_record(&mut cursor).unwrap();
-            dbg!(&parsed);
+            let _parsed = parse_mrt_record(&mut cursor).unwrap();
         }
     }
 }

--- a/src/encoder/updates_encoder.rs
+++ b/src/encoder/updates_encoder.rs
@@ -96,8 +96,7 @@ mod tests {
 
         let mut cursor = Cursor::new(bytes.clone());
         while cursor.has_remaining() {
-            let parsed = parse_mrt_record(&mut cursor).unwrap();
-            dbg!(&parsed);
+            let _parsed = parse_mrt_record(&mut cursor).unwrap();
         }
     }
 
@@ -113,8 +112,7 @@ mod tests {
         let bytes = encoder.export_bytes();
         let mut cursor = Cursor::new(bytes.clone());
         while cursor.has_remaining() {
-            let parsed = parse_mrt_record(&mut cursor).unwrap();
-            dbg!(&parsed);
+            let _parsed = parse_mrt_record(&mut cursor).unwrap();
         }
     }
 }

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -1072,7 +1072,6 @@ mod tests {
     fn test_get_collector() {
         let aspath = AsPath::from_sequence([1, 2, 3, 5]);
         let collector = aspath.get_collector_opt();
-        dbg!(&collector);
         assert_eq!(collector.unwrap(), 1);
 
         let aspath = AsPath::from_segments(vec![AsPathSegment::set([7])]);

--- a/src/parser/bmp/messages/headers.rs
+++ b/src/parser/bmp/messages/headers.rs
@@ -95,7 +95,7 @@ pub fn parse_bmp_common_header(data: &mut Bytes) -> Result<BmpCommonHeader, Pars
 ///      |                  Timestamp (microseconds)                     |
 ///      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BmpPerPeerHeader {
     pub peer_type: BmpPeerType,
     pub peer_flags: PerPeerFlags,
@@ -124,7 +124,7 @@ impl BmpPerPeerHeader {
 ///
 /// - RFC7854: https://datatracker.ietf.org/doc/html/rfc7854#section-4.2
 /// - RFC9069: https://datatracker.ietf.org/doc/html/rfc9069
-#[derive(Debug, TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Hash)]
+#[derive(Debug, TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Hash, Clone)]
 #[repr(u8)]
 pub enum BmpPeerType {
     Global = 0,

--- a/src/parser/bmp/messages/initiation_message.rs
+++ b/src/parser/bmp/messages/initiation_message.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, Bytes};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InitiationMessage {
     pub tlvs: Vec<InitiationTlv>,
 }
@@ -18,13 +18,15 @@ pub struct InitiationTlv {
 
 ///Type-Length-Value Type
 ///
-/// For more, see: https://datatracker.ietf.org/doc/html/rfc1213
+/// https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#initiation-peer-up-tlvs
 #[derive(Debug, TryFromPrimitive, IntoPrimitive, PartialEq, Clone, Copy)]
 #[repr(u16)]
 pub enum InitiationTlvType {
     String = 0,
     SysDescr = 1,
     SysName = 2,
+    VrTableName = 3,
+    AdminLabel = 4,
 }
 
 /// Parse BMP initiation message

--- a/src/parser/bmp/messages/route_mirroring.rs
+++ b/src/parser/bmp/messages/route_mirroring.rs
@@ -6,18 +6,18 @@ use bytes::{Buf, Bytes};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RouteMirroring {
     pub tlvs: Vec<RouteMirroringTlv>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RouteMirroringTlv {
     pub info_len: u16,
     pub value: RouteMirroringValue,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum RouteMirroringValue {
     BgpMessage(BgpMessage),
     Information(RouteMirroringInfo),

--- a/src/parser/bmp/messages/route_monitoring.rs
+++ b/src/parser/bmp/messages/route_monitoring.rs
@@ -3,7 +3,7 @@ use crate::parser::bgp::messages::parse_bgp_message;
 use crate::parser::bmp::error::ParserBmpError;
 use bytes::Bytes;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RouteMonitoring {
     pub bgp_message: BgpMessage,
 }

--- a/src/parser/bmp/messages/stats_report.rs
+++ b/src/parser/bmp/messages/stats_report.rs
@@ -3,18 +3,26 @@ use crate::parser::ReadUtils;
 use bytes::{Buf, Bytes};
 use num_enum::{FromPrimitive, IntoPrimitive};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StatsReport {
     pub stats_count: u32,
     pub counters: Vec<StatCounter>,
 }
 
 /// Statistics count values
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StatCounter {
     pub stat_type: StatType,
     pub stat_len: u16,
     pub stat_data: StatsData,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum StatsData {
+    Counter(u32),
+    Gauge(u64),
+    AfiSafiGauge(u16, u8, u64),
+    Unknown(Vec<u8>),
 }
 
 /// Stats counter types enum
@@ -43,14 +51,6 @@ pub enum StatType {
     RoutesInPerAfiSafiPostPolicyAdjRibOut = 17,
     #[num_enum(catch_all)]
     Other(u16) = 65535,
-}
-
-#[derive(Debug)]
-pub enum StatsData {
-    Counter(u32),
-    Gauge(u64),
-    AfiSafiGauge(u16, u8, u64),
-    Unknown(Vec<u8>),
 }
 
 pub fn parse_stats_report(data: &mut Bytes) -> Result<StatsReport, ParserBmpError> {

--- a/src/parser/bmp/messages/termination_message.rs
+++ b/src/parser/bmp/messages/termination_message.rs
@@ -4,16 +4,32 @@ use bytes::{Buf, Bytes};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TerminationMessage {
     pub tlvs: Vec<TerminationTlv>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TerminationTlv {
     pub info_type: TerminationTlvType,
     pub info_len: u16,
-    pub info: String,
+    pub info_value: TerminationTlvValue,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum TerminationTlvValue {
+    String(String),
+    Reason(TerminationReason),
+}
+
+#[derive(Debug, TryFromPrimitive, IntoPrimitive, PartialEq, Clone, Copy)]
+#[repr(u16)]
+pub enum TerminationReason {
+    AdministrativelyClosed = 0,
+    UnspecifiedReason = 1,
+    OutOfResources = 2,
+    RedundantConnection = 3,
+    PermanentlyAdministrativelyClosed = 4,
 }
 
 ///Type-Length-Value Type
@@ -36,11 +52,20 @@ pub fn parse_termination_message(data: &mut Bytes) -> Result<TerminationMessage,
             // not enough bytes to read
             break;
         }
-        let info = data.read_n_bytes_to_string(info_len as usize)?;
+        let info_value = match info_type {
+            TerminationTlvType::String => {
+                let info = data.read_n_bytes_to_string(info_len as usize)?;
+                TerminationTlvValue::String(info)
+            }
+            TerminationTlvType::Reason => {
+                let reason = TerminationReason::try_from(data.read_u16()?)?;
+                TerminationTlvValue::Reason(reason)
+            }
+        };
         tlvs.push(TerminationTlv {
             info_type,
             info_len,
-            info,
+            info_value,
         })
     }
 
@@ -60,8 +85,8 @@ mod tests {
             0, 5, // info_len: 5
             67, 79, 68, 69, 83, // info: "CODES"
             0, 1, // info_type: Reason
-            0, 4, // info_len: 4
-            84, 69, 83, 84, // info: "TEST"
+            0, 2, // info_len: 2
+            0, 1, // info: UnspecifiedReason
         ]);
 
         // Check if parse_termination_message correctly reads the data
@@ -76,15 +101,21 @@ mod tests {
                     TerminationTlvType::String
                 );
                 assert_eq!(termination_message.tlvs[0].info_len, 5);
-                assert_eq!(termination_message.tlvs[0].info, "CODES");
+                assert_eq!(
+                    termination_message.tlvs[0].info_value,
+                    TerminationTlvValue::String("CODES".to_string())
+                );
 
                 // tlvs[1] assertions
                 assert_eq!(
                     termination_message.tlvs[1].info_type,
                     TerminationTlvType::Reason
                 );
-                assert_eq!(termination_message.tlvs[1].info_len, 4);
-                assert_eq!(termination_message.tlvs[1].info, "TEST");
+                assert_eq!(termination_message.tlvs[1].info_len, 2);
+                assert_eq!(
+                    termination_message.tlvs[1].info_value,
+                    TerminationTlvValue::Reason(TerminationReason::UnspecifiedReason)
+                );
             }
             Err(e) => panic!("Failed to parse: {}", e),
         }

--- a/src/parser/mrt/messages/table_dump_v2/mod.rs
+++ b/src/parser/mrt/messages/table_dump_v2/mod.rs
@@ -60,7 +60,6 @@ mod tests {
     #[test]
     fn test_unsupported_type() {
         let msg = parse_table_dump_v2_message(7, Bytes::new());
-        dbg!(&msg);
         assert!(msg.is_err());
     }
 }


### PR DESCRIPTION
This PR adds support for more BMP data types and fixes parsing issues for Statistics Report type (see #162).

The code base should be in sync with IANA BMP code definitions: https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml