### PR TITLE
fix a bug where as4path not used when same length

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,19 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Build
-      run: cargo build
+      - name: Build
+        run: cargo build
 
-    - name: Build cli
-      run: cargo build --features cli
+      - name: Build cli
+        run: cargo build --features cli
 
-    - name: Build no-default-features
-      run: cargo build --no-default-features
+      - name: Build no-default-features
+        run: cargo build --no-default-features
 
-    - name: Run tests
-      run: cargo test --all-features
+      - name: Run tests
+        run: cargo test --all-features
 
-    - name: Run clippy
-      run: cargo clippy --all-features -- -D warnings
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/src/encoder/rib_encoder.rs
+++ b/src/encoder/rib_encoder.rs
@@ -141,9 +141,11 @@ mod tests {
     #[test]
     fn test_encoding_rib() {
         let mut encoder = MrtRibEncoder::new();
-        let mut elem = BgpElem::default();
-        elem.peer_ip = IpAddr::V4("10.0.0.1".parse().unwrap());
-        elem.peer_asn = Asn::from(65000);
+        let mut elem = BgpElem {
+            peer_ip: IpAddr::V4("10.0.0.1".parse().unwrap()),
+            peer_asn: Asn::from(65000),
+            ..Default::default()
+        };
         elem.prefix.prefix = "10.250.0.0/24".parse().unwrap();
         encoder.process_elem(&elem);
         elem.prefix.prefix = "10.251.0.0/24".parse().unwrap();
@@ -157,9 +159,11 @@ mod tests {
 
         // v6
         let mut encoder = MrtRibEncoder::new();
-        let mut elem = BgpElem::default();
-        elem.peer_ip = IpAddr::V6("::1".parse().unwrap());
-        elem.peer_asn = Asn::from(65000);
+        let mut elem = BgpElem {
+            peer_ip: IpAddr::V6("::1".parse().unwrap()),
+            peer_asn: Asn::from(65000),
+            ..Default::default()
+        };
         // ipv6 prefix
         elem.prefix.prefix = "2001:db8::/32".parse().unwrap();
         encoder.process_elem(&elem);

--- a/src/encoder/updates_encoder.rs
+++ b/src/encoder/updates_encoder.rs
@@ -85,9 +85,11 @@ mod tests {
     #[test]
     fn test_encoding_updates() {
         let mut encoder = MrtUpdatesEncoder::new();
-        let mut elem = BgpElem::default();
-        elem.peer_ip = IpAddr::V4("10.0.0.1".parse().unwrap());
-        elem.peer_asn = Asn::from(65000);
+        let mut elem = BgpElem {
+            peer_ip: IpAddr::V4("10.0.0.1".parse().unwrap()),
+            peer_asn: Asn::from(65000),
+            ..Default::default()
+        };
         elem.prefix.prefix = "10.250.0.0/24".parse().unwrap();
         encoder.process_elem(&elem);
         elem.prefix.prefix = "10.251.0.0/24".parse().unwrap();
@@ -103,9 +105,12 @@ mod tests {
     #[test]
     fn test_encoding_updates_v6() {
         let mut encoder = MrtUpdatesEncoder::new();
-        let mut elem = BgpElem::default();
-        elem.peer_ip = IpAddr::V6("::1".parse().unwrap());
-        elem.peer_asn = Asn::from(65000);
+
+        let mut elem = BgpElem {
+            peer_ip: IpAddr::V6("::1".parse().unwrap()),
+            peer_asn: Asn::from(65000),
+            ..Default::default()
+        };
         // ipv6 prefix
         elem.prefix = NetworkPrefix::from_str("2001:db8::/32").unwrap();
         encoder.process_elem(&elem);

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -636,8 +636,10 @@ impl AsPath {
                             new_seq.extend(seq.iter().take(diff_len as usize));
                             new_seq.extend(seq4);
                             new_segs.push(AsPathSegment::AsSequence(new_seq));
-                        } else {
+                        } else if diff_len < 0 {
                             new_segs.push(AsPathSegment::AsSequence(seq.clone()));
+                        } else {
+                            new_segs.push(AsPathSegment::AsSequence(seq4.clone()));
                         }
                     } else {
                         new_segs.push(as4seg_unwrapped.clone());
@@ -997,6 +999,12 @@ mod tests {
         let as4path = AsPath::from_sequence([2, 3, 7]);
         let newpath = AsPath::merge_aspath_as4path(&aspath, &as4path);
         assert_eq!(newpath.segments[0], AsPathSegment::sequence([1, 2]));
+
+        // when the sequence length is the same, the as4path should be used
+        let aspath = AsPath::from_sequence([1, 2]);
+        let as4path = AsPath::from_sequence([3, 4]);
+        let newpath = AsPath::merge_aspath_as4path(&aspath, &as4path);
+        assert_eq!(newpath.segments[0], AsPathSegment::sequence([3, 4]));
 
         let aspath = AsPath::from_segments(vec![
             AsPathSegment::sequence([1, 2, 3, 5]),

--- a/src/models/bgp/attributes/aspath.rs
+++ b/src/models/bgp/attributes/aspath.rs
@@ -629,17 +629,21 @@ impl AsPath {
                         (seg, as4seg_unwrapped)
                     {
                         let diff_len = seq.len() as i32 - seq4.len() as i32;
-                        if diff_len > 0 {
-                            // 2-byte ASN path is longer than 4-byte ASN path
-                            // we take the leading part of 2-byte ASN path and prepend it to 4-byte ASN path
-                            let mut new_seq: Vec<Asn> = vec![];
-                            new_seq.extend(seq.iter().take(diff_len as usize));
-                            new_seq.extend(seq4);
-                            new_segs.push(AsPathSegment::AsSequence(new_seq));
-                        } else if diff_len < 0 {
-                            new_segs.push(AsPathSegment::AsSequence(seq.clone()));
-                        } else {
-                            new_segs.push(AsPathSegment::AsSequence(seq4.clone()));
+                        match diff_len {
+                            d if d > 0 => {
+                                // 2-byte ASN path is longer than 4-byte ASN path
+                                // we take the leading part of 2-byte ASN path and prepend it to 4-byte ASN path
+                                let mut new_seq: Vec<Asn> = vec![];
+                                new_seq.extend(seq.iter().take(d as usize));
+                                new_seq.extend(seq4);
+                                new_segs.push(AsPathSegment::AsSequence(new_seq));
+                            }
+                            d if d < 0 => {
+                                new_segs.push(AsPathSegment::AsSequence(seq.clone()));
+                            }
+                            _ => {
+                                new_segs.push(AsPathSegment::AsSequence(seq4.clone()));
+                            }
                         }
                     } else {
                         new_segs.push(as4seg_unwrapped.clone());

--- a/src/models/bgp/attributes/mod.rs
+++ b/src/models/bgp/attributes/mod.rs
@@ -609,7 +609,7 @@ mod tests {
         let mut attributes = Attributes::default();
         attributes.add_attr(attribute);
 
-        assert_eq!(attributes.has_attr(AttrType::ORIGIN), true);
+        assert!(attributes.has_attr(AttrType::ORIGIN));
     }
 
     #[test]
@@ -681,7 +681,7 @@ mod tests {
         );
         assert_eq!(
             attributes.origin_id(),
-            Some(Ipv4Addr::from_str("0.0.0.0").unwrap().into())
+            Some(Ipv4Addr::from_str("0.0.0.0").unwrap())
         );
 
         let aspath_attr = attributes.get_attr(AttrType::AS_PATH).unwrap();

--- a/src/models/bgp/attributes/nlri.rs
+++ b/src/models/bgp/attributes/nlri.rs
@@ -162,7 +162,7 @@ mod tests {
             Some("10.0.2.1".parse().unwrap()),
         );
 
-        assert_eq!(nlri.is_reachable(), true);
+        assert!(nlri.is_reachable());
     }
 
     #[test]

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -597,7 +597,7 @@ mod tests {
         assert_eq!(msg.asn, Asn::new_16bit(1));
         assert_eq!(msg.hold_time, 180);
         assert_eq!(msg.sender_ip, Ipv4Addr::new(192, 0, 2, 1));
-        assert_eq!(msg.extended_length, false);
+        assert!(!msg.extended_length);
         assert_eq!(msg.opt_params.len(), 0);
     }
 

--- a/src/parser/bmp/messages/route_mirroring.rs
+++ b/src/parser/bmp/messages/route_mirroring.rs
@@ -98,7 +98,7 @@ mod tests {
                 let tlv = &route_mirroring.tlvs[0];
                 assert_eq!(tlv.info_len, actual_info_len);
             }
-            Err(_) => assert!(false),
+            Err(_) => panic!("Error parsing route mirroring"),
         }
     }
 
@@ -117,7 +117,7 @@ mod tests {
             RouteMirroringValue::Information(info) => {
                 assert_eq!(info, &RouteMirroringInfo::ErroredPdu)
             }
-            _ => assert!(false),
+            _ => panic!("Expected RouteMirroringValue::Information"),
         }
     }
 }

--- a/src/parser/mrt/mrt_elem.rs
+++ b/src/parser/mrt/mrt_elem.rs
@@ -620,13 +620,13 @@ mod tests {
         let _elems = elementor.record_to_elems(peer_index_table);
         let record = record_iter.next().unwrap();
         let elems = elementor.record_to_elems(record);
-        assert!(elems.len() >= 1);
+        assert!(!elems.is_empty());
 
         let parser = BgpkitParser::new(url_bgp4mp).unwrap();
         let mut record_iter = parser.into_record_iter();
         let record = record_iter.next().unwrap();
         let elems = elementor.record_to_elems(record);
-        assert!(elems.len() >= 1);
+        assert!(!elems.is_empty());
     }
 
     #[test]
@@ -725,7 +725,7 @@ mod tests {
             }),
         ]
         .into_iter()
-        .map(|v| Attribute::from(v))
+        .map(Attribute::from)
         .collect::<Vec<Attribute>>();
 
         let attributes = Attributes::from(attributes);


### PR DESCRIPTION

This pull request includes changes to the `src/models/bgp/attributes/aspath.rs` file to handle different sequence lengths in AS path merging and to add new test cases for these scenarios. The most important changes are:

### Handling Different Sequence Lengths:
* Modified `impl AsPath` to handle cases where `diff_len` is zero or negative, ensuring the correct AS path sequence is used. (`src/models/bgp/attributes/aspath.rs`, [src/models/bgp/attributes/aspath.rsL639-R642](diffhunk://#diff-355b738265864622d172e2834b2a2d048736ebb8f75b9763f93f7a5f6551de4bL639-R642))

### Adding Test Cases:
* Added new test cases to verify the behavior when the sequence length is the same, ensuring the `as4path` is used in such scenarios. (`src/models/bgp/attributes/aspath.rs`, [src/models/bgp/attributes/aspath.rsR1003-R1008](diffhunk://#diff-355b738265864622d172e2834b2a2d048736ebb8f75b9763f93f7a5f6551de4bR1003-R1008))