### PR TITLE
Fix next_hop parsing for IPv6

### DIFF
--- a/benches/data_source.rs
+++ b/benches/data_source.rs
@@ -1,7 +1,7 @@
 use md5::Digest;
 use oneio::get_reader;
 use std::fs::{create_dir_all, File};
-use std::io::{self, BufWriter, ErrorKind, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Once;
 
@@ -119,8 +119,7 @@ impl<W: Write> Write for HashingWriter<W> {
 fn download_file<P: AsRef<Path>>(url: &str, target: P) -> io::Result<Digest> {
     let target_path = target.as_ref().to_str().unwrap().to_string();
 
-    oneio::download(url, target_path.as_str(), None)
-        .map_err(|err| io::Error::new(ErrorKind::Other, err))?;
+    oneio::download(url, target_path.as_str(), None).map_err(io::Error::other)?;
 
     let mut reader = get_reader(target_path.as_str()).unwrap();
     let mut writer = HashingWriter {

--- a/src/models/network/prefix.rs
+++ b/src/models/network/prefix.rs
@@ -70,7 +70,7 @@ impl NetworkPrefix {
         // encode prefix
 
         let bit_len = self.prefix.prefix_len();
-        let byte_len = ((bit_len + 7) / 8) as usize;
+        let byte_len = bit_len.div_ceil(8) as usize;
         bytes.put_u8(bit_len);
 
         match self.prefix {

--- a/src/parser/bgp/attributes/mod.rs
+++ b/src/parser/bgp/attributes/mod.rs
@@ -198,9 +198,9 @@ pub fn parse_attributes(
             Err(e) => {
                 if partial {
                     // it's ok to have errors when reading partial bytes
-                    debug!("PARTIAL: {}", e.to_string());
+                    debug!("PARTIAL: {}", e);
                 } else {
-                    debug!("{}", e.to_string());
+                    debug!("{}", e);
                 }
                 continue;
             }

--- a/src/parser/bmp/error.rs
+++ b/src/parser/bmp/error.rs
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn test_error_conversions() {
         assert_eq!(
-            ParserBmpError::from(std::io::Error::new(std::io::ErrorKind::Other, "test")),
+            ParserBmpError::from(std::io::Error::other("test")),
             ParserBmpError::InvalidOpenBmpHeader
         );
         assert_eq!(

--- a/src/parser/mrt/messages/table_dump_v2/rib_afi_entries.rs
+++ b/src/parser/mrt/messages/table_dump_v2/rib_afi_entries.rs
@@ -71,7 +71,7 @@ pub fn parse_rib_afi_entries(
         let entry = match parse_rib_entry(data, add_path, &afi, &safi, prefix) {
             Ok(entry) => entry,
             Err(e) => {
-                warn!("early break due to error {}", e.to_string());
+                warn!("early break due to error {}", e);
                 break;
             }
         };

--- a/src/parser/mrt/mrt_elem.rs
+++ b/src/parser/mrt/mrt_elem.rs
@@ -118,24 +118,15 @@ fn get_relevant_attributes(
     };
 
     // If the next_hop is not set, we try to get it from the announced NLRI.
-    let next_hop = match next_hop {
-        None => {
-            if let Some(v) = &announced {
-                if let Some(h) = v.next_hop {
-                    match h {
-                        NextHopAddress::Ipv4(v) => Some(IpAddr::from(v)),
-                        NextHopAddress::Ipv6(v) => Some(IpAddr::from(v)),
-                        NextHopAddress::Ipv6LinkLocal(v, _) => Some(IpAddr::from(v)),
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-        Some(v) => Some(v),
-    };
+    let next_hop = next_hop.or_else(|| {
+        announced.as_ref().and_then(|v| {
+            v.next_hop.as_ref().map(|h| match h {
+                NextHopAddress::Ipv4(v) => IpAddr::from(*v),
+                NextHopAddress::Ipv6(v) => IpAddr::from(*v),
+                NextHopAddress::Ipv6LinkLocal(v, _) => IpAddr::from(*v),
+            })
+        })
+    });
 
     (
         as_path,

--- a/src/parser/mrt/mrt_elem.rs
+++ b/src/parser/mrt/mrt_elem.rs
@@ -117,6 +117,26 @@ fn get_relevant_attributes(
         false => None,
     };
 
+    // If the next_hop is not set, we try to get it from the announced NLRI.
+    let next_hop = match next_hop {
+        None => {
+            if let Some(v) = &announced {
+                if let Some(h) = v.next_hop {
+                    match h {
+                        NextHopAddress::Ipv4(v) => Some(IpAddr::from(v)),
+                        NextHopAddress::Ipv6(v) => Some(IpAddr::from(v)),
+                        NextHopAddress::Ipv6LinkLocal(v, _) => Some(IpAddr::from(v)),
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        Some(v) => Some(v),
+    };
+
     (
         as_path,
         as4_path,
@@ -746,5 +766,65 @@ mod tests {
             _unknown,
             _deprecated,
         ) = get_relevant_attributes(attributes);
+    }
+
+    #[test]
+    fn test_next_hop_from_nlri() {
+        let attributes = vec![AttributeValue::NextHop(
+            IpAddr::from_str("10.0.0.1").unwrap(),
+        )]
+        .into_iter()
+        .map(Attribute::from)
+        .collect::<Vec<Attribute>>();
+
+        let attributes = Attributes::from(attributes);
+
+        let (
+            _as_path,
+            _as4_path, // Table dump v1 does not have 4-byte AS number
+            _origin,
+            next_hop,
+            _local_pref,
+            _med,
+            _communities,
+            _atomic,
+            _aggregator,
+            _announced,
+            _withdrawn,
+            _only_to_customer,
+            _unknown,
+            _deprecated,
+        ) = get_relevant_attributes(attributes);
+
+        assert_eq!(next_hop, Some(IpAddr::from_str("10.0.0.1").unwrap()));
+
+        let attributes = vec![AttributeValue::MpReachNlri(Nlri::new_reachable(
+            NetworkPrefix::from_str("10.0.0.0/24").unwrap(),
+            Some(IpAddr::from_str("10.0.0.2").unwrap()),
+        ))]
+        .into_iter()
+        .map(Attribute::from)
+        .collect::<Vec<Attribute>>();
+
+        let attributes = Attributes::from(attributes);
+
+        let (
+            _as_path,
+            _as4_path, // Table dump v1 does not have 4-byte AS number
+            _origin,
+            next_hop,
+            _local_pref,
+            _med,
+            _communities,
+            _atomic,
+            _aggregator,
+            _announced,
+            _withdrawn,
+            _only_to_customer,
+            _unknown,
+            _deprecated,
+        ) = get_relevant_attributes(attributes);
+
+        assert_eq!(next_hop, Some(IpAddr::from_str("10.0.0.2").unwrap()));
     }
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -453,6 +453,15 @@ mod tests {
                 0x2001, 0x0DB8, 0x85A3, 0x0000, 0x0000, 0x8A2E, 0x0370, 0x7334
             ))
         );
+
+        let mut buf = Bytes::from_static(&[0xC0, 0xA8, 0x01]);
+        assert!(buf.read_address(&Afi::Ipv4).is_err());
+
+        let mut buf = Bytes::from_static(&[
+            0x20, 0x01, 0x0D, 0xB8, 0x85, 0xA3, 0x00, 0x00, 0x00, 0x00, 0x8A, 0x2E, 0x03, 0x70,
+            0x73,
+        ]);
+        assert!(buf.read_address(&Afi::Ipv6).is_err());
     }
 
     #[test]
@@ -512,6 +521,10 @@ mod tests {
             buf.read_ipv4_prefix().unwrap(),
             Ipv4Net::new(Ipv4Addr::new(192, 168, 1, 1), 24).unwrap()
         );
+
+        // Test with invalid IPv4 prefix mask, /33
+        let mut buf = Bytes::from_static(&[0xC0, 0xA8, 0x01, 0x01, 0x21]);
+        assert!(buf.read_ipv4_prefix().is_err());
     }
 
     #[test]
@@ -528,6 +541,13 @@ mod tests {
             )
             .unwrap()
         );
+
+        // Test with invalid IPv6 prefix mask, /129
+        let mut buf = Bytes::from_static(&[
+            0x20, 0x01, 0x0D, 0xB8, 0x85, 0xA3, 0x00, 0x00, 0x00, 0x00, 0x8A, 0x2E, 0x03, 0x70,
+            0x73, 0x34, 0x81,
+        ]);
+        assert!(buf.read_ipv6_prefix().is_err());
     }
 
     #[test]

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -67,17 +67,11 @@ pub trait ReadUtils: Buf {
         match afi {
             Afi::Ipv4 => match self.read_ipv4_address() {
                 Ok(ip) => Ok(IpAddr::V4(ip)),
-                _ => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Cannot parse IPv4 address".to_string(),
-                )),
+                _ => Err(io::Error::other("Cannot parse IPv4 address")),
             },
             Afi::Ipv6 => match self.read_ipv6_address() {
                 Ok(ip) => Ok(IpAddr::V6(ip)),
-                _ => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Cannot parse IPv6 address".to_string(),
-                )),
+                _ => Err(io::Error::other("Cannot parse IPv6 address")),
             },
         }
     }
@@ -98,7 +92,7 @@ pub trait ReadUtils: Buf {
         let mask = self.read_u8()?;
         match Ipv4Net::new(addr, mask) {
             Ok(n) => Ok(n),
-            Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid prefix mask").into()),
+            Err(_) => Err(io::Error::other("Invalid prefix mask").into()),
         }
     }
 
@@ -107,7 +101,7 @@ pub trait ReadUtils: Buf {
         let mask = self.read_u8()?;
         match Ipv6Net::new(addr, mask) {
             Ok(n) => Ok(n),
-            Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid prefix mask").into()),
+            Err(_) => Err(io::Error::other("Invalid prefix mask").into()),
         }
     }
 
@@ -164,7 +158,7 @@ pub trait ReadUtils: Buf {
         let bit_len = self.read_u8()?;
 
         // Convert to bytes
-        let byte_len: usize = (bit_len as usize + 7) / 8;
+        let byte_len: usize = (bit_len as usize).div_ceil(8);
         let addr: IpAddr = match afi {
             Afi::Ipv4 => {
                 // 4 bytes -- u32


### PR DESCRIPTION



### Fix `next_hop` parsing from NLRI:
* [`src/parser/mrt/mrt_elem.rs`](diffhunk://#diff-85a6f0ed4f2f52824c6f0f3a0b5ae6a1544d8ac7e67a4063b8d29d8ddc0a88a1R120-R139): Enhanced the `get_relevant_attributes` function to extract the `next_hop` attribute from the announced NLRI when it is not explicitly set.

### Test coverage:
* [`src/parser/mrt/mrt_elem.rs`](diffhunk://#diff-85a6f0ed4f2f52824c6f0f3a0b5ae6a1544d8ac7e67a4063b8d29d8ddc0a88a1R770-R829): Added a new test, `test_next_hop_from_nlri`, to validate the behavior of extracting the `next_hop` attribute from NLRI and ensure correctness in different scenarios.
### Cargo clippy improvements:
* [`src/models/network/prefix.rs`](diffhunk://#diff-4586dbe178695bb141bf7e7c4e48b72271478ad97e3201bb1e4e56337789f45fL73-R73): Replaced manual ceiling division calculation with the `div_ceil` method to improve readability and reduce potential errors.
* [`src/parser/utils.rs`](diffhunk://#diff-058a224670b67ab6c41b6d177ace78c82cbdc28da1daf0cce6c056b8c485b2a5L70-R74): Updated multiple methods to use `io::Error::other` for simplified and consistent error handling. [[1]](diffhunk://#diff-058a224670b67ab6c41b6d177ace78c82cbdc28da1daf0cce6c056b8c485b2a5L70-R74) [[2]](diffhunk://#diff-058a224670b67ab6c41b6d177ace78c82cbdc28da1daf0cce6c056b8c485b2a5L101-R95) [[3]](diffhunk://#diff-058a224670b67ab6c41b6d177ace78c82cbdc28da1daf0cce6c056b8c485b2a5L110-R104)
* [`src/parser/utils.rs`](diffhunk://#diff-058a224670b67ab6c41b6d177ace78c82cbdc28da1daf0cce6c056b8c485b2a5L167-R161): Replaced manual byte length calculation with the `div_ceil` method in `pub trait ReadUtils` for consistency and clarity.
