### PR TITLE
Pre allocate Vec of correct size for community parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ required-features = ["serde"]
 name = "deprecated_attributes"
 required-features = ["serde"]
 
+[[example]]
+name = "scan_mrt"
+required-features = ["cli"]
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"

--- a/examples/scan_mrt.rs
+++ b/examples/scan_mrt.rs
@@ -1,0 +1,102 @@
+use bgpkit_parser::BgpkitParser;
+use clap::{Parser, ValueEnum};
+use std::io::Read;
+use std::path::PathBuf;
+use tracing::info;
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Operation {
+    Records,
+    Elements,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "scan_mrt")]
+#[command(about = "Scan over the elements of a MRT file without processing")]
+struct Cli {
+    #[arg(help = "Path to MRT file to parse")]
+    rib_file: PathBuf,
+
+    #[arg(short, long, action = clap::ArgAction::Count, help = "Increase verbosity (-v, -vv, -vvv)")]
+    verbose: u8,
+
+    #[arg(short, long, help = "Limit number of records to process")]
+    limit: Option<usize>,
+
+    operation: Operation,
+}
+
+fn scan_records<R: Read>(
+    parser: BgpkitParser<R>,
+    limit: Option<usize>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut element_count = 0;
+
+    for (idx, _) in parser.into_record_iter().enumerate() {
+        if let Some(limit) = limit {
+            if idx >= limit {
+                break;
+            }
+        }
+
+        // Just counting elements without processing
+        element_count += 1;
+    }
+
+    Ok(element_count)
+}
+
+fn scan_elements<R: Read>(
+    parser: BgpkitParser<R>,
+    limit: Option<usize>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut element_count = 0;
+
+    for (idx, _) in parser.into_elem_iter().enumerate() {
+        if let Some(limit) = limit {
+            if idx >= limit {
+                break;
+            }
+        }
+
+        // Just counting elements without processing
+        element_count += 1;
+    }
+
+    Ok(element_count)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(match cli.verbose {
+            0 => tracing::Level::INFO,
+            1 => tracing::Level::DEBUG,
+            2 => tracing::Level::TRACE,
+            _ => tracing::Level::ERROR,
+        })
+        .init();
+
+    info!("Scanning RIB file: {}", cli.rib_file.display());
+
+    let parser = BgpkitParser::new(cli.rib_file.to_str().unwrap())?;
+
+    let t0 = std::time::Instant::now();
+
+    let element_count = match cli.operation {
+        Operation::Records => scan_records(parser, cli.limit)?,
+        Operation::Elements => scan_elements(parser, cli.limit)?,
+    };
+
+    let elapsed = t0.elapsed();
+
+    info!(
+        "Scanning complete: read {} bytes of input in {:.3} seconds.",
+        cli.rib_file.metadata()?.len(),
+        elapsed.as_secs_f64()
+    );
+    info!("Total BGP elements scanned: {}", element_count);
+
+    Ok(())
+}

--- a/src/parser/bgp/attributes/attr_08_communities.rs
+++ b/src/parser/bgp/attributes/attr_08_communities.rs
@@ -29,7 +29,7 @@ pub fn parse_regular_communities(mut input: Bytes) -> Result<AttributeValue, Par
 }
 
 pub fn encode_regular_communities(communities: &Vec<Community>) -> Bytes {
-    let mut bytes = BytesMut::new();
+    let mut bytes = BytesMut::with_capacity(4 * communities.len());
 
     for community in communities {
         match community {
@@ -43,6 +43,7 @@ pub fn encode_regular_communities(communities: &Vec<Community>) -> Bytes {
         }
     }
 
+    debug_assert!(bytes.len() == bytes.capacity());
     bytes.freeze()
 }
 

--- a/src/parser/bgp/attributes/attr_08_communities.rs
+++ b/src/parser/bgp/attributes/attr_08_communities.rs
@@ -8,7 +8,8 @@ const COMMUNITY_NO_ADVERTISE: u32 = 0xFFFFFF02;
 const COMMUNITY_NO_EXPORT_SUBCONFED: u32 = 0xFFFFFF03;
 
 pub fn parse_regular_communities(mut input: Bytes) -> Result<AttributeValue, ParserError> {
-    let mut communities = vec![];
+    // RFC 1997: [..] Communities are treated as 32 bit values [..]
+    let mut communities = Vec::with_capacity(input.remaining() / 4);
 
     while input.remaining() > 0 {
         let community_val = input.read_u32()?;

--- a/src/parser/bgp/attributes/attr_16_25_extended_communities.rs
+++ b/src/parser/bgp/attributes/attr_16_25_extended_communities.rs
@@ -11,7 +11,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::net::Ipv4Addr;
 
 pub fn parse_extended_community(mut input: Bytes) -> Result<AttributeValue, ParserError> {
-    let mut communities = Vec::new();
+    // RFC 4360, section 2: Each Extended Community is encoded as an 8-octet quantity [..]
+    let mut communities = Vec::with_capacity(input.remaining() / 8);
 
     while input.remaining() > 0 {
         let ec_type_u8 = input.read_u8()?;
@@ -162,7 +163,8 @@ pub fn parse_extended_community(mut input: Bytes) -> Result<AttributeValue, Pars
 }
 
 pub fn parse_ipv6_extended_community(mut input: Bytes) -> Result<AttributeValue, ParserError> {
-    let mut communities = Vec::new();
+    // RFC 5701, section 2: Each IPv6 Address Specific extended community is encoded as a 20-octet quantity [..]
+    let mut communities = Vec::with_capacity(input.remaining() / 20);
     while input.remaining() > 0 {
         let ec_type_u8 = input.read_u8()?;
         let sub_type = input.read_u8()?;

--- a/src/parser/bgp/attributes/attr_32_large_communities.rs
+++ b/src/parser/bgp/attributes/attr_32_large_communities.rs
@@ -4,7 +4,8 @@ use crate::ParserError;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 pub fn parse_large_communities(mut input: Bytes) -> Result<AttributeValue, ParserError> {
-    let mut communities = Vec::new();
+    // RFC 8092, section 3: Each BGP Large Community value is encoded as a 12-octet quantity [..]
+    let mut communities = Vec::with_capacity(input.remaining() / 12);
     while input.remaining() > 0 {
         input.has_n_remaining(12)?; // 12 bytes for large community (3x 32 bits integers)
         let global_administrator = input.get_u32();


### PR DESCRIPTION
First, I added an example that just "scans" (iterates without touching any object) a RIB file using the record or element iterator. Then, when profiling, I noticed that a significant amount of time was spent on resizing specific Vecs, I pre-allocated Vecs of the corrrect size in community parsing.

±4-5% of CPU time was spent in re-sizing (and allocating) a Vec when parsing a RIB. This change pre-allocates a Vec of the correct size.

Note that there is a performance regression since 0.11.1 - which warrants a separate investigation.

Transcript of the performance change, using hyperfine on an otherwise completely idle  machine with AMD EPYC 7502P processor follows below.

```
Before:
$ hyperfine "./target/release/examples/scan_mrt ~/bview.20250101.0000.gz elements"
Benchmark 1: ./target/release/examples/scan_mrt ~/bview.20250101.0000.gz elements
  Time (mean ± σ):     70.117 s ±  1.019 s    [User: 69.762 s, System: 0.070 s]
  Range (min … max):   69.119 s … 72.314 s    10 runs

$ git stash pop
On branch feature/pre-allocate-vecs
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/parser/bgp/attributes/attr_08_communities.rs
        modified:   src/parser/bgp/attributes/attr_16_25_extended_communities.rs
        modified:   src/parser/bgp/attributes/attr_32_large_communities.rs

$ cargo build --release --examples --features=cli
   Compiling bgpkit-parser v0.11.1 (/home/tdekock/src/bgpkit-parser)
    Finished `release` profile [optimized] target(s) in 6.18s

After:
$ hyperfine "./target/release/examples/scan_mrt ~/bview.20250101.0000.gz elements"
Benchmark 1: ./target/release/examples/scan_mrt ~/bview.20250101.0000.gz elements
  Time (mean ± σ):     66.255 s ±  0.584 s    [User: 65.920 s, System: 0.068 s]
  Range (min … max):   65.716 s … 67.643 s    10 runs
```