### PR TITLE
feat: add RFC 8654 Extended Message Support for BGP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 
 ### Code improvements
 
+* add support for RFC 8654 Extended Messages
+  * updated message length validation to support extended messages up to 65535 bytes
+  * resolves parsing errors for large BGP messages (e.g., "invalid BGP message length 4834")
+  * implemented BGP Extended Message capability (capability code 6) for parsing and encoding
+  * added proper RFC 8654 validation constraints (OPEN and KEEPALIVE messages remain limited to 4096 bytes)
+  * added test cases for extended message length validation and capability parsing
 * optimized BytesMut buffer allocation patterns for better memory efficiency
     * replaced `BytesMut::with_capacity() + resize()` with `BytesMut::zeroed()` for cleaner initialization
     * added capacity pre-allocation in ASN encoding to avoid reallocations

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 - [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
 - [X] [RFC 7606](https://datatracker.ietf.org/doc/html/rfc7606): Revised Error Handling for BGP UPDATE Messages
 - [X] [RFC 7911](https://datatracker.ietf.org/doc/html/rfc7911): Advertisement of Multiple Paths in BGP (ADD-PATH)
+- [X] [RFC 8654](https://datatracker.ietf.org/doc/html/rfc8654): Extended Message Support for BGP
 - [X] [RFC 8950](https://datatracker.ietf.org/doc/html/rfc8950): Advertising IPv4 Network Layer Reachability Information (NLRI) with an IPv6 Next Hop
 - [X] [RFC 9072](https://datatracker.ietf.org/doc/html/rfc9072): Extended Optional Parameters Length for BGP OPEN Message Updates
 - [X] [RFC 9234](https://datatracker.ietf.org/doc/html/rfc9234):  Route Leak Prevention and Detection Using Roles in UPDATE and OPEN Messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,7 @@ If you would like to see any specific RFC's support, please submit an issue on G
 - [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
 - [X] [RFC 7606](https://datatracker.ietf.org/doc/html/rfc7606): Revised Error Handling for BGP UPDATE Messages
 - [X] [RFC 7911](https://datatracker.ietf.org/doc/html/rfc7911): Advertisement of Multiple Paths in BGP (ADD-PATH)
+- [X] [RFC 8654](https://datatracker.ietf.org/doc/html/rfc8654): Extended Message Support for BGP
 - [X] [RFC 8950](https://datatracker.ietf.org/doc/html/rfc8950): Advertising IPv4 Network Layer Reachability Information (NLRI) with an IPv6 Next Hop
 - [X] [RFC 9072](https://datatracker.ietf.org/doc/html/rfc9072): Extended Optional Parameters Length for BGP OPEN Message Updates
 - [X] [RFC 9234](https://datatracker.ietf.org/doc/html/rfc9234):  Route Leak Prevention and Detection Using Roles in UPDATE and OPEN Messages

--- a/src/models/bgp/mod.rs
+++ b/src/models/bgp/mod.rs
@@ -21,9 +21,9 @@ pub use tunnel_encap::*;
 
 use crate::models::network::*;
 use capabilities::{
-    AddPathCapability, BgpCapabilityType, BgpRoleCapability, ExtendedNextHopCapability,
-    FourOctetAsCapability, GracefulRestartCapability, MultiprotocolExtensionsCapability,
-    RouteRefreshCapability,
+    AddPathCapability, BgpCapabilityType, BgpExtendedMessageCapability, BgpRoleCapability,
+    ExtendedNextHopCapability, FourOctetAsCapability, GracefulRestartCapability,
+    MultiprotocolExtensionsCapability, RouteRefreshCapability,
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::net::Ipv4Addr;
@@ -139,6 +139,8 @@ pub enum CapabilityValue {
     AddPath(AddPathCapability),
     /// BGP Role capability - RFC 9234
     BgpRole(BgpRoleCapability),
+    /// BGP Extended Message capability - RFC 8654
+    BgpExtendedMessage(BgpExtendedMessageCapability),
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Eq)]

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -4,9 +4,9 @@ use std::convert::TryFrom;
 
 use crate::error::ParserError;
 use crate::models::capabilities::{
-    AddPathCapability, BgpCapabilityType, BgpRoleCapability, ExtendedNextHopCapability,
-    FourOctetAsCapability, GracefulRestartCapability, MultiprotocolExtensionsCapability,
-    RouteRefreshCapability,
+    AddPathCapability, BgpCapabilityType, BgpExtendedMessageCapability, BgpRoleCapability,
+    ExtendedNextHopCapability, FourOctetAsCapability, GracefulRestartCapability,
+    MultiprotocolExtensionsCapability, RouteRefreshCapability,
 };
 use crate::models::error::BgpError;
 use crate::parser::bgp::attributes::parse_attributes;
@@ -51,7 +51,15 @@ pub fn parse_bgp_message(
     message.
     */
     let length = data.get_u16();
-    if !(19..=4096).contains(&length) {
+
+    // Validate message length according to RFC 8654
+    // For now, we allow extended messages for all message types except when we know
+    // for certain that extended messages are not supported.
+    // RFC 8654: Extended messages up to 65535 bytes are allowed for all message types
+    // except OPEN and KEEPALIVE (which remain limited to 4096 bytes).
+    // However, since we're parsing MRT data without session context, we'll be permissive.
+    let max_length = 65535; // RFC 8654 maximum
+    if !(19..=max_length).contains(&length) {
         return Err(ParserError::ParseError(format!(
             "invalid BGP message length {length}"
         )));
@@ -71,6 +79,28 @@ pub fn parse_bgp_message(
             ))
         }
     };
+
+    // Additional validation for OPEN and KEEPALIVE messages per RFC 8654
+    // These message types cannot exceed 4096 bytes even with extended message capability
+    match msg_type {
+        BgpMessageType::OPEN | BgpMessageType::KEEPALIVE => {
+            if length > 4096 {
+                return Err(ParserError::ParseError(format!(
+                    "BGP {} message length {} exceeds maximum allowed 4096 bytes (RFC 8654)",
+                    match msg_type {
+                        BgpMessageType::OPEN => "OPEN",
+                        BgpMessageType::KEEPALIVE => "KEEPALIVE",
+                        _ => unreachable!(),
+                    },
+                    length
+                )));
+            }
+        }
+        BgpMessageType::UPDATE | BgpMessageType::NOTIFICATION => {
+            // These can be extended messages up to 65535 bytes when capability is negotiated
+            // Since we're parsing MRT data, we allow extended lengths
+        }
+    }
 
     if data.remaining() != bgp_msg_length {
         warn!(
@@ -239,6 +269,9 @@ pub fn parse_bgp_open_message(input: &mut Bytes) -> Result<BgpOpenMessage, Parse
                     BgpCapabilityType::BGP_ROLE => {
                         parse_capability!(BgpRoleCapability::parse, BgpRole)
                     }
+                    BgpCapabilityType::BGP_EXTENDED_MESSAGE => {
+                        parse_capability!(BgpExtendedMessageCapability::parse, BgpExtendedMessage)
+                    }
                     _ => CapabilityValue::Raw(capability_data),
                 };
 
@@ -292,6 +325,7 @@ impl BgpOpenMessage {
                         CapabilityValue::FourOctetAs(foa) => foa.encode(),
                         CapabilityValue::AddPath(ap) => ap.encode(),
                         CapabilityValue::BgpRole(br) => br.encode(),
+                        CapabilityValue::BgpExtendedMessage(bem) => bem.encode(),
                         CapabilityValue::Raw(raw) => Bytes::from(raw.clone()),
                     };
                     buf.put_u8(encoded_value.len() as u8);
@@ -770,6 +804,112 @@ mod tests {
                 assert!(!enh_cap.supports(Afi::Ipv4, Safi::Multicast, Afi::Ipv6));
             } else {
                 panic!("Expected ExtendedNextHop capability value");
+            }
+        } else {
+            panic!("Expected capability parameter");
+        }
+    }
+
+    #[test]
+    fn test_rfc8654_extended_message_length_validation() {
+        // Test valid extended UPDATE message (within 65535 limit)
+        let bytes = Bytes::from_static(&[
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x13, 0x00, // length = 4864 (extended message)
+            0x02, // type = UPDATE
+            0x00, 0x00, // withdrawn length
+            0x00,
+            0x00, // path attribute length
+                  // No NLRI data needed for this test
+        ]);
+        let mut data = bytes.clone();
+        // This should succeed because UPDATE messages can be extended
+        assert!(parse_bgp_message(&mut data, false, &AsnLength::Bits16).is_ok());
+
+        // Test OPEN message exceeding 4096 bytes (should fail)
+        let bytes = Bytes::from_static(&[
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x13, 0x00, // length = 4864 (exceeds 4096 for OPEN)
+            0x01, // type = OPEN
+        ]);
+        let mut data = bytes.clone();
+        let result = parse_bgp_message(&mut data, false, &AsnLength::Bits16);
+        assert!(result.is_err());
+        if let Err(ParserError::ParseError(msg)) = result {
+            assert!(msg.contains("BGP OPEN message length"));
+            assert!(msg.contains("4096 bytes"));
+        }
+
+        // Test KEEPALIVE message exceeding 4096 bytes (should fail)
+        let bytes = Bytes::from_static(&[
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x13, 0x00, // length = 4864 (exceeds 4096 for KEEPALIVE)
+            0x04, // type = KEEPALIVE
+        ]);
+        let mut data = bytes.clone();
+        let result = parse_bgp_message(&mut data, false, &AsnLength::Bits16);
+        assert!(result.is_err());
+        if let Err(ParserError::ParseError(msg)) = result {
+            assert!(msg.contains("BGP KEEPALIVE message length"));
+            assert!(msg.contains("4096 bytes"));
+        }
+
+        // Test message exceeding 65535 bytes (maximum allowed)
+        let bytes = Bytes::from_static(&[
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0x00, 0x00, 0x00, 0x00, // marker
+            0xFF, 0xFF, // length = 65535 (maximum allowed)
+            0x02, // type = UPDATE
+        ]);
+        let mut data = bytes.clone();
+        // This might fail due to insufficient data, but should not fail on length validation
+        let result = parse_bgp_message(&mut data, false, &AsnLength::Bits16);
+        if let Err(ParserError::ParseError(msg)) = result {
+            // Should not be a length validation error
+            assert!(!msg.contains("invalid BGP message length"));
+        }
+    }
+
+    #[test]
+    fn test_bgp_extended_message_capability_parsing() {
+        use crate::models::CapabilityValue;
+
+        // Test BGP OPEN message with Extended Message capability (capability code 6)
+        let bytes = Bytes::from(vec![
+            0x04, // version
+            0x00, 0x01, // asn
+            0x00, 0xb4, // hold time
+            0xc0, 0x00, 0x02, 0x01, // sender ip
+            0x04, // opt params length = 4
+            0x02, // param type = 2 (capability)
+            0x02, // param length = 2
+            0x06, // capability type = 6 (Extended Message)
+            0x00, // capability length = 0 (no parameters)
+        ]);
+
+        let msg = parse_bgp_open_message(&mut bytes.clone()).unwrap();
+        assert_eq!(msg.version, 4);
+        assert_eq!(msg.asn, Asn::new_16bit(1));
+        assert_eq!(msg.opt_params.len(), 1);
+
+        // Check that we have the extended message capability
+        if let ParamValue::Capability(cap) = &msg.opt_params[0].param_value {
+            assert_eq!(cap.ty, BgpCapabilityType::BGP_EXTENDED_MESSAGE);
+            if let CapabilityValue::BgpExtendedMessage(_) = &cap.value {
+                // Extended Message capability should have no parameters
+            } else {
+                panic!("Expected BgpExtendedMessage capability value");
             }
         } else {
             panic!("Expected capability parameter");


### PR DESCRIPTION
## Summary

- Implements RFC 8654 Extended Message Support for BGP to handle large BGP messages
- Resolves parsing errors for BGP messages exceeding the traditional 4096-byte limit
- Adds BGP Extended Message capability (capability code 6) parsing and encoding
- Updates message length validation to support messages up to 65535 bytes

## Changes Made

- **BGP Extended Message Capability**: Added complete implementation with parsing/encoding support
- **Message Length Validation**: Updated to allow up to 65535 bytes for UPDATE and NOTIFICATION messages
- **RFC 8654 Compliance**: OPEN and KEEPALIVE messages remain limited to 4096 bytes as specified
- **Test Coverage**: Added comprehensive tests for capability parsing and message validation
- **Documentation**: Updated supported RFCs list and added detailed changelog entry

## Fixes

Closes #240 - resolves "invalid BGP message length" errors when parsing MRT files containing large BGP messages (e.g., BGPsec signatures, extensive BGP-LS attributes)

## Compatibility

- Backward compatible with existing BGP message parsing
- No breaking changes to public API
- Maintains all existing validation for standard-length messages