### PR TITLE
Security/rtr oob and dos fixes

### DIFF
--- a/src/models/bgp/flowspec/nlri.rs
+++ b/src/models/bgp/flowspec/nlri.rs
@@ -135,6 +135,14 @@ fn parse_prefix_component(data: &[u8], offset: &mut usize) -> Result<NetworkPref
     let prefix_len = data[*offset];
     *offset += 1;
 
+    // Reject prefix lengths beyond the IPv6 maximum. Without this,
+    // `prefix_bytes` can reach 32 and the IPv6 branch below would copy past
+    // the fixed 16-byte buffer and panic. The `Ipv6Net::new` validation only
+    // runs *after* the copy, so the check must happen here.
+    if prefix_len > 128 {
+        return Err(FlowSpecError::InvalidPrefix);
+    }
+
     let prefix_bytes = prefix_len.div_ceil(8);
     if *offset + prefix_bytes as usize > data.len() {
         return Err(FlowSpecError::InsufficientData);
@@ -397,6 +405,21 @@ fn encode_bitmask_operators(operators: &[BitmaskOperator], data: &mut Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: an oversized prefix length (>128) must be rejected before
+    /// the address bytes are copied, rather than panicking on an out-of-bounds
+    /// copy into the fixed 16-byte buffer.
+    #[test]
+    fn test_parse_prefix_component_oversized_len_no_panic() {
+        // prefix_len = 0xFF (255) → 32 prefix bytes, followed by 32 bytes.
+        let mut data = vec![0xFF];
+        data.extend(std::iter::repeat_n(0u8, 32));
+        let mut offset = 0;
+        assert!(matches!(
+            parse_prefix_component(&data, &mut offset),
+            Err(FlowSpecError::InvalidPrefix)
+        ));
+    }
 
     #[test]
     fn test_length_encoding() {

--- a/src/parser/bmp/openbmp.rs
+++ b/src/parser/bmp/openbmp.rs
@@ -96,10 +96,11 @@ pub fn parse_openbmp_header(data: &mut Bytes) -> Result<OpenBmpHeader, ParserBmp
     // read admin-id
     data.has_n_remaining(16)?;
     data.advance(16);
-    let mut name_len = data.read_u16()?;
-    if name_len > 255 {
-        name_len = 255;
-    }
+    // Consume exactly the declared admin-id length. Clamping it (to e.g. 255)
+    // would leave the unread remainder to be misparsed as the following
+    // fields (router hash/IP); `read_n_bytes_to_string` already bounds-checks
+    // against the remaining buffer and errors on truncation.
+    let name_len = data.read_u16()?;
     let admin_id = data.read_n_bytes_to_string(name_len as usize)?;
 
     // read router IP

--- a/src/parser/iters/route.rs
+++ b/src/parser/iters/route.rs
@@ -429,10 +429,10 @@ fn parse_bgp4mp_routes(
     let _local_asn = data.read_asn(asn_len)?;
     let _interface_index = data.read_u16()?;
     let afi = data.read_afi()?;
+    let should_read = bgp4mp_message_payload_len(&afi, &asn_len, total_size)?;
     let peer_ip = data.read_address(&afi)?;
     let _local_ip = data.read_address(&afi)?;
 
-    let should_read = bgp4mp_message_payload_len(&afi, &asn_len, total_size);
     if should_read != data.remaining() {
         return Err(ParserError::TruncatedMsg(format!(
             "truncated bgp4mp message: should read {} bytes, have {} bytes available",
@@ -1103,6 +1103,27 @@ mod tests {
 
         assert_eq!(routes, elem_projection);
         routes
+    }
+
+    #[test]
+    fn bgp4mp_routes_rejects_link_state_envelope_afi() {
+        let mut data = BytesMut::new();
+        data.put_u16(65000);
+        data.put_u16(65001);
+        data.put_u16(0);
+        data.put_u16(Afi::LinkState as u16);
+        data.extend(&BgpMessage::KeepAlive.encode(AsnLength::Bits16));
+
+        let error =
+            match parse_bgp4mp_routes(Bgp4MpType::Message as u16, data.freeze(), 1_700_000_000.0) {
+                Err(error) => error,
+                Ok(_) => panic!("unexpectedly parsed BGP4MP routes"),
+            };
+        assert!(matches!(
+            error,
+            ParserError::ParseError(message)
+                if message == "Link-State AFI is invalid in a BGP4MP envelope"
+        ));
     }
 
     #[test]

--- a/src/parser/mrt/messages/bgp4mp.rs
+++ b/src/parser/mrt/messages/bgp4mp.rs
@@ -86,18 +86,25 @@ pub fn parse_bgp4mp(sub_type: u16, input: Bytes) -> Result<Bgp4MpEnum, ParserErr
   |                    BGP Message... (variable)
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 */
+pub(crate) fn validate_bgp4mp_afi(afi: &Afi) -> Result<(), ParserError> {
+    match afi {
+        Afi::Ipv4 | Afi::Ipv6 => Ok(()),
+        Afi::LinkState => Err(ParserError::ParseError(
+            "Link-State AFI is invalid in a BGP4MP envelope".to_string(),
+        )),
+    }
+}
+
 pub(crate) fn bgp4mp_message_payload_len(
     afi: &Afi,
     asn_len: &AsnLength,
     total_size: usize,
-) -> usize {
-    let ip_size = match afi {
-        Afi::Ipv4 => 4 * 2,
-        Afi::Ipv6 => 16 * 2,
-        // `read_address` consumes 0 bytes for Link-State (it returns a
-        // placeholder), so no address bytes are subtracted here. Using a
-        // non-zero size would underflow `total_size` for small records.
-        Afi::LinkState => 0,
+) -> Result<usize, ParserError> {
+    validate_bgp4mp_afi(afi)?;
+    let ip_size = if matches!(afi, Afi::Ipv4) {
+        4 * 2
+    } else {
+        16 * 2
     };
     let asn_size = match asn_len {
         AsnLength::Bits16 => 2 * 2,
@@ -106,11 +113,11 @@ pub(crate) fn bgp4mp_message_payload_len(
     // Saturating: on a truncated/inconsistent record the caller compares the
     // result against `data.remaining()` and rejects the mismatch, so a
     // saturated 0 simply fails that check instead of underflowing.
-    total_size
+    Ok(total_size
         .saturating_sub(asn_size)
         .saturating_sub(2)
         .saturating_sub(2)
-        .saturating_sub(ip_size)
+        .saturating_sub(ip_size))
 }
 /*
    0                   1                   2                   3
@@ -139,10 +146,10 @@ pub fn parse_bgp4mp_message(
     let local_asn: Asn = data.read_asn(asn_len)?;
     let interface_index: u16 = data.read_u16()?;
     let afi: Afi = data.read_afi()?;
+    let should_read = bgp4mp_message_payload_len(&afi, &asn_len, total_size)?;
     let peer_ip = data.read_address(&afi)?;
     let local_ip = data.read_address(&afi)?;
 
-    let should_read = bgp4mp_message_payload_len(&afi, &asn_len, total_size);
     if should_read != data.remaining() {
         return Err(ParserError::TruncatedMsg(format!(
             "truncated bgp4mp message: should read {} bytes, have {} bytes available",
@@ -217,6 +224,7 @@ pub fn parse_bgp4mp_state_change(
     let local_asn: Asn = input.read_asn(asn_len)?;
     let interface_index: u16 = input.read_u16()?;
     let address_family: Afi = input.read_afi()?;
+    validate_bgp4mp_afi(&address_family)?;
     let peer_ip = input.read_address(&address_family)?;
     let local_addr = input.read_address(&address_family)?;
     let old_state = BgpState::try_from(input.read_u16()?)?;
@@ -280,5 +288,46 @@ mod tests {
             }
             other => panic!("unexpected BGP4MP message: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_bgp4mp_message_rejects_link_state_envelope_afi() {
+        let mut data = BytesMut::new();
+        data.put_u16(65000);
+        data.put_u16(65001);
+        data.put_u16(0);
+        data.put_u16(Afi::LinkState as u16);
+        data.extend(&BgpMessage::KeepAlive.encode(AsnLength::Bits16));
+
+        let error = match parse_bgp4mp(Bgp4MpType::Message as u16, data.freeze()) {
+            Err(error) => error,
+            Ok(message) => panic!("unexpectedly parsed BGP4MP message: {message:?}"),
+        };
+        assert!(matches!(
+            error,
+            ParserError::ParseError(message)
+                if message == "Link-State AFI is invalid in a BGP4MP envelope"
+        ));
+    }
+
+    #[test]
+    fn test_bgp4mp_state_change_rejects_link_state_envelope_afi() {
+        let mut data = BytesMut::new();
+        data.put_u16(65000);
+        data.put_u16(65001);
+        data.put_u16(0);
+        data.put_u16(Afi::LinkState as u16);
+        data.put_u16(BgpState::Idle as u16);
+        data.put_u16(BgpState::Connect as u16);
+
+        let error = match parse_bgp4mp(Bgp4MpType::StateChange as u16, data.freeze()) {
+            Err(error) => error,
+            Ok(message) => panic!("unexpectedly parsed BGP4MP state change: {message:?}"),
+        };
+        assert!(matches!(
+            error,
+            ParserError::ParseError(message)
+                if message == "Link-State AFI is invalid in a BGP4MP envelope"
+        ));
     }
 }

--- a/src/parser/mrt/messages/bgp4mp.rs
+++ b/src/parser/mrt/messages/bgp4mp.rs
@@ -94,13 +94,23 @@ pub(crate) fn bgp4mp_message_payload_len(
     let ip_size = match afi {
         Afi::Ipv4 => 4 * 2,
         Afi::Ipv6 => 16 * 2,
-        Afi::LinkState => 4 * 2, // Link-State uses IPv4 format for compatibility
+        // `read_address` consumes 0 bytes for Link-State (it returns a
+        // placeholder), so no address bytes are subtracted here. Using a
+        // non-zero size would underflow `total_size` for small records.
+        Afi::LinkState => 0,
     };
     let asn_size = match asn_len {
         AsnLength::Bits16 => 2 * 2,
         AsnLength::Bits32 => 2 * 4,
     };
-    total_size - asn_size - 2 - 2 - ip_size
+    // Saturating: on a truncated/inconsistent record the caller compares the
+    // result against `data.remaining()` and rejects the mismatch, so a
+    // saturated 0 simply fails that check instead of underflowing.
+    total_size
+        .saturating_sub(asn_size)
+        .saturating_sub(2)
+        .saturating_sub(2)
+        .saturating_sub(ip_size)
 }
 /*
    0                   1                   2                   3

--- a/src/parser/rpki/rtr.rs
+++ b/src/parser/rpki/rtr.rs
@@ -172,18 +172,29 @@ pub const RTR_CACHE_RESET_LEN: u32 = 8;
 /// Router Key PDU minimum length (header(8) + flags(1) + zero(1) + SKI(20) + ASN(4) = 34)
 pub const RTR_ROUTER_KEY_MIN_LEN: u32 = 34;
 
-/// Maximum accepted RTR PDU length.
+/// Practical maximum length of an RTR PDU other than Error Report.
 ///
 /// The wire `length` field is a 32-bit value (up to ~4 GiB), but every RTR
-/// PDU type has a far smaller real maximum. The largest variable-length PDU
-/// is the ASPA PDU (RFC 8210-bis, §5.12): an 8-byte common header, a 4-byte
-/// Customer ASN, and a list of 4-byte Provider ASNs whose count is derived
-/// from `Length` as `(Length - 12) / 4`. That spec explicitly states the
-/// PDU length "MUST NOT exceed 65,535 octets", which is the largest a valid
-/// RTR PDU of any type can be. Capping here bounds the allocation in
+/// PDU type has a far smaller practical maximum. The largest variable-length
+/// non-error PDU is the ASPA PDU (RFC 8210-bis, §5.12): an 8-byte common
+/// header, a 4-byte Customer ASN, and a list of 4-byte Provider ASNs whose
+/// count is derived from `Length` as `(Length - 12) / 4`. That spec
+/// explicitly states the PDU length "MUST NOT exceed 65,535 octets". Error
+/// Report PDUs can legitimately be larger (see [`RTR_MAX_ERROR_REPORT_LEN`]).
+pub const RTR_MAX_PDU_LEN: usize = 65_535;
+
+/// Maximum accepted RTR PDU length, used to cap the allocation in
 /// [`read_rtr_pdu`] so a crafted header cannot drive a large allocation
 /// (memory-exhaustion DoS).
-pub const RTR_MAX_PDU_LEN: usize = 65_535;
+///
+/// Sized for the largest PDU: an Error Report (RFC 8210, §5.10), which
+/// encapsulates a copy of the erroneous PDU plus a diagnostic text:
+/// header(8) + encapsulated PDU length(4) + encapsulated PDU + error text
+/// length(4) + error text. The encapsulated PDU is itself at most
+/// [`RTR_MAX_PDU_LEN`]; the RFC places no explicit bound on the text, so the
+/// same 65,535 octets is used as a practical cap. Applied to every PDU type
+/// for simplicity, this keeps the worst-case allocation around 128 KiB.
+pub const RTR_MAX_ERROR_REPORT_LEN: usize = 8 + 4 + RTR_MAX_PDU_LEN + 4 + RTR_MAX_PDU_LEN;
 
 // =============================================================================
 // Parsing Functions
@@ -413,10 +424,13 @@ pub fn parse_rtr_pdu(input: &[u8]) -> Result<(RtrPdu, usize), RtrError> {
             let encap_pdu_len =
                 u32::from_be_bytes([input[8], input[9], input[10], input[11]]) as usize;
 
-            // Validate encapsulated PDU fits
-            if 12 + encap_pdu_len + 4 > length_usize {
+            // Validate encapsulated PDU fits. `encap_pdu_len` is
+            // wire-controlled, so compare by subtraction (`length >= 16` was
+            // checked above) rather than addition, which could overflow
+            // `usize` on 32-bit targets and bypass the check.
+            if encap_pdu_len > length_usize - 16 {
                 return Err(RtrError::InvalidLength {
-                    expected: (12 + encap_pdu_len + 4) as u32,
+                    expected: u32::try_from(encap_pdu_len.saturating_add(16)).unwrap_or(u32::MAX),
                     actual: length,
                     pdu_type: pdu_type_byte,
                 });
@@ -439,12 +453,16 @@ pub fn parse_rtr_pdu(input: &[u8]) -> Result<(RtrPdu, usize), RtrError> {
             let error_text_offset = error_text_len_offset + 4;
 
             // Validate the declared error text actually fits within the PDU
-            // before slicing. `length` is a wire-controlled u32, and
-            // `error_text_len` is independent of it, so an oversized value
-            // would otherwise index past the buffer and panic.
-            if error_text_offset + error_text_len > length_usize {
+            // before slicing: `error_text_len` is wire-controlled and
+            // independent of `length`, so an oversized value would otherwise
+            // index past the buffer and panic. Compare by subtraction (the
+            // check above guarantees `error_text_offset <= length_usize`)
+            // rather than addition, which could overflow `usize` on 32-bit
+            // targets and bypass the check.
+            if error_text_len > length_usize - error_text_offset {
                 return Err(RtrError::InvalidLength {
-                    expected: (error_text_offset + error_text_len) as u32,
+                    expected: u32::try_from(error_text_offset.saturating_add(error_text_len))
+                        .unwrap_or(u32::MAX),
                     actual: length,
                     pdu_type: pdu_type_byte,
                 });
@@ -505,9 +523,9 @@ pub fn read_rtr_pdu<R: Read>(reader: &mut R) -> Result<RtrPdu, RtrError> {
 
     // Reject implausibly large PDUs before allocating, so a crafted header
     // cannot drive a multi-gigabyte allocation (memory-exhaustion DoS).
-    if length > RTR_MAX_PDU_LEN {
+    if length > RTR_MAX_ERROR_REPORT_LEN {
         return Err(RtrError::InvalidLength {
-            expected: RTR_MAX_PDU_LEN as u32,
+            expected: RTR_MAX_ERROR_REPORT_LEN as u32,
             actual: length as u32,
             pdu_type: header[1],
         });
@@ -1576,5 +1594,33 @@ mod tests {
             read_rtr_pdu(&mut reader),
             Err(RtrError::InvalidLength { .. })
         ));
+    }
+
+    /// An ErrorReport encapsulating a maximum-size PDU plus error text is
+    /// larger than `RTR_MAX_PDU_LEN` but still valid; the allocation cap in
+    /// `read_rtr_pdu` must not reject it.
+    #[test]
+    fn test_read_rtr_pdu_accepts_large_error_report() {
+        let encap_len = RTR_MAX_PDU_LEN; // 65,535-byte erroneous PDU copy
+        let text = "diagnostic text".repeat(10);
+        let length = 8 + 4 + encap_len + 4 + text.len();
+        assert!(length > RTR_MAX_PDU_LEN);
+        assert!(length <= RTR_MAX_ERROR_REPORT_LEN);
+
+        let mut bytes: Vec<u8> = vec![0x01, 0x0A, 0x00, 0x00]; // ver=1, type=10, error_code=0
+        bytes.extend((length as u32).to_be_bytes());
+        bytes.extend((encap_len as u32).to_be_bytes());
+        bytes.extend(std::iter::repeat_n(0xAAu8, encap_len));
+        bytes.extend((text.len() as u32).to_be_bytes());
+        bytes.extend(text.as_bytes());
+
+        let mut reader = std::io::Cursor::new(bytes);
+        match read_rtr_pdu(&mut reader).unwrap() {
+            RtrPdu::ErrorReport(report) => {
+                assert_eq!(report.erroneous_pdu.len(), encap_len);
+                assert_eq!(report.error_text, text);
+            }
+            _ => panic!("Expected ErrorReport"),
+        }
     }
 }

--- a/src/parser/rpki/rtr.rs
+++ b/src/parser/rpki/rtr.rs
@@ -172,6 +172,19 @@ pub const RTR_CACHE_RESET_LEN: u32 = 8;
 /// Router Key PDU minimum length (header(8) + flags(1) + zero(1) + SKI(20) + ASN(4) = 34)
 pub const RTR_ROUTER_KEY_MIN_LEN: u32 = 34;
 
+/// Maximum accepted RTR PDU length.
+///
+/// The wire `length` field is a 32-bit value (up to ~4 GiB), but every RTR
+/// PDU type has a far smaller real maximum. The largest variable-length PDU
+/// is the ASPA PDU (RFC 8210-bis, §5.12): an 8-byte common header, a 4-byte
+/// Customer ASN, and a list of 4-byte Provider ASNs whose count is derived
+/// from `Length` as `(Length - 12) / 4`. That spec explicitly states the
+/// PDU length "MUST NOT exceed 65,535 octets", which is the largest a valid
+/// RTR PDU of any type can be. Capping here bounds the allocation in
+/// [`read_rtr_pdu`] so a crafted header cannot drive a large allocation
+/// (memory-exhaustion DoS).
+pub const RTR_MAX_PDU_LEN: usize = 65_535;
+
 // =============================================================================
 // Parsing Functions
 // =============================================================================
@@ -424,6 +437,19 @@ pub fn parse_rtr_pdu(input: &[u8]) -> Result<(RtrPdu, usize), RtrError> {
             ]) as usize;
 
             let error_text_offset = error_text_len_offset + 4;
+
+            // Validate the declared error text actually fits within the PDU
+            // before slicing. `length` is a wire-controlled u32, and
+            // `error_text_len` is independent of it, so an oversized value
+            // would otherwise index past the buffer and panic.
+            if error_text_offset + error_text_len > length_usize {
+                return Err(RtrError::InvalidLength {
+                    expected: (error_text_offset + error_text_len) as u32,
+                    actual: length,
+                    pdu_type: pdu_type_byte,
+                });
+            }
+
             let error_text = if error_text_len > 0 {
                 std::str::from_utf8(&input[error_text_offset..error_text_offset + error_text_len])
                     .map_err(|_| RtrError::InvalidUtf8)?
@@ -472,6 +498,16 @@ pub fn read_rtr_pdu<R: Read>(reader: &mut R) -> Result<RtrPdu, RtrError> {
     if length < RTR_HEADER_LEN {
         return Err(RtrError::InvalidLength {
             expected: RTR_HEADER_LEN as u32,
+            actual: length as u32,
+            pdu_type: header[1],
+        });
+    }
+
+    // Reject implausibly large PDUs before allocating, so a crafted header
+    // cannot drive a multi-gigabyte allocation (memory-exhaustion DoS).
+    if length > RTR_MAX_PDU_LEN {
+        return Err(RtrError::InvalidLength {
+            expected: RTR_MAX_PDU_LEN as u32,
             actual: length as u32,
             pdu_type: header[1],
         });
@@ -1507,5 +1543,38 @@ mod tests {
             }
             _ => panic!("Expected ErrorReport"),
         }
+    }
+
+    /// Regression: an ErrorReport declaring an `error_text_len` larger than the
+    /// buffer must return an error rather than panic on an out-of-bounds slice.
+    #[test]
+    fn test_error_report_oversized_text_len_no_panic() {
+        let bytes: Vec<u8> = vec![
+            0x01, 0x0A, 0x00, 0x00, // ver=1, type=10 (ErrorReport), error_code=0
+            0x00, 0x00, 0x00, 0x10, // length = 16
+            0x00, 0x00, 0x00, 0x00, // encap_pdu_len = 0
+            0xFF, 0xFF, 0xFF, 0xFF, // error_text_len = 0xFFFFFFFF (huge)
+        ];
+        assert!(matches!(
+            parse_rtr_pdu(&bytes),
+            Err(RtrError::InvalidLength { .. })
+        ));
+    }
+
+    /// Regression: `read_rtr_pdu` must reject an implausibly large declared
+    /// length before allocating, rather than attempting a multi-gigabyte
+    /// allocation (memory-exhaustion DoS).
+    #[test]
+    fn test_read_rtr_pdu_rejects_oversized_length() {
+        // Header claims length = 0xFFFFFFFF but no body follows.
+        let header: Vec<u8> = vec![
+            0x01, 0x03, 0x00, 0x00, // ver=1, type=3 (ResetQuery)
+            0xFF, 0xFF, 0xFF, 0xFF, // length = 0xFFFFFFFF
+        ];
+        let mut reader = std::io::Cursor::new(header);
+        assert!(matches!(
+            read_rtr_pdu(&mut reader),
+            Err(RtrError::InvalidLength { .. })
+        ));
     }
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -118,17 +118,27 @@ pub trait ReadUtils: Buf {
     }
 
     fn read_asns(&mut self, as_length: &AsnLength, count: usize) -> Result<Vec<Asn>, ParserError> {
-        let mut path = Vec::with_capacity(count);
+        // Verify the bytes are actually present before allocating, so a large
+        // `count` cannot pre-allocate memory the buffer could never fill.
+        // `checked_mul` guards against overflow of `count * width` on 32-bit
+        // targets.
+        let width = match as_length {
+            AsnLength::Bits16 => 2,
+            AsnLength::Bits32 => 4,
+        };
+        let needed = count
+            .checked_mul(width)
+            .ok_or_else(|| TruncatedMsg("ASN count overflows buffer length".to_string()))?;
+        self.has_n_remaining(needed)?;
 
+        let mut path = Vec::with_capacity(count);
         match as_length {
             AsnLength::Bits16 => {
-                self.has_n_remaining(count * 2)?; // 2 bytes for 16-bit ASN
                 for _ in 0..count {
                     path.push(Asn::new_16bit(self.read_u16()?));
                 }
             }
             AsnLength::Bits32 => {
-                self.has_n_remaining(count * 4)?; // 4 bytes for 32-bit ASN
                 for _ in 0..count {
                     path.push(Asn::new_32bit(self.read_u32()?));
                 }

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -75,3 +75,10 @@ path = "fuzz_targets/fuzz_mrt_header.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_rtr"
+path = "fuzz_targets/fuzz_rtr.rs"
+test = false
+doc = false
+bench = false

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -22,6 +22,9 @@ cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_bgp_message -- -max_total_tim
 # Full parser fuzzing (60s)
 cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_parser -- -max_total_time=60
 
+# RPKI RTR PDU fuzzing (60s)
+cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_rtr -- -max_total_time=60
+
 # Run all fuzzers (5 minutes each)
 cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_mrt_record -- -max_total_time=300
 cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_bgp_message -- -max_total_time=300

--- a/tests/fuzz/fuzz_targets/fuzz_rtr.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_rtr.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use bgpkit_parser::parser::rpki::rtr::{parse_rtr_pdu, read_rtr_pdu};
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    // Slice-based single-PDU parser: must never panic (OOB slice, underflow).
+    let _ = parse_rtr_pdu(data);
+
+    // Reader-based parser: must never panic and must not attempt an
+    // implausibly large allocation from a crafted length field.
+    let mut cursor = Cursor::new(data);
+    let _ = read_rtr_pdu(&mut cursor);
+});


### PR DESCRIPTION
Very much AI assisted changes. Review and fixes by Opus 4.8. The issues are known weak spots in TLV parsers, and the changes look logical (I do not know LinkState/BMP well enough to judge those though).