### PR TITLE
feat: RFC 7606 non-fatal NLRI parsing and treat-as-withdrawal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+* **RFC 7606 non-fatal NLRI parsing**: Malformed NLRI fields (withdrawn or announced) no longer cause the entire BGP UPDATE message to be discarded. Instead, the parser returns the UPDATE with partial prefix data and records a `BgpValidationWarning::MalformedNlri` warning containing the raw NLRI bytes, enabling callers to emulate RFC 7606 treat-as-withdrawal semantics. Attribute framing errors (truncated length fields, inconsistent data) remain fatal. ([#303](https://github.com/bgpkit/bgpkit-parser/issues/303))
+* **Raw bytes preserved on MRT body-parse failures**: `parse_mrt_record` now attaches the original MRT record bytes to `ParserErrorWithBytes.bytes` when the message body fails to parse, enabling forensic analysis and record export. Previously `bytes` was always `None` for body-level failures. ([#303](https://github.com/bgpkit/bgpkit-parser/issues/303))
+* **Treat-as-withdrawal example**: Added `examples/treat_as_withdrawal.rs` demonstrating how to scan MRT files for RFC 7606 validation issues, classify them by error-handling category (attribute discard vs. treat-as-withdrawal), and extract raw malformed NLRI bytes.
 * **Extended element filtering**: Added `Filter` variants for nine previously unfilterable `BgpElem` fields: `only_to_customer` (`otc`), `next_hop`, `origin`, `local_pref`, `med`, `atomic`, `aggr_asn`, `aggr_ip`, and `peer_bgp_id`. Each optional field also supports presence filtering via the `*` wildcard — e.g. `otc=*` matches elements that carry an OTC value, `otc=!*` matches elements without one. ([#306](https://github.com/bgpkit/bgpkit-parser/issues/306))
 * **MRT attribute code counter example**: Added `examples/count_attributes.rs`, which reports every parsed BGP path-attribute wire code in a local or remote MRT file, including raw-retained unsupported, deprecated, and unassigned attributes.
 * **RTR PDU fuzzer**: Added `fuzz_rtr` fuzz target for RPKI RTR PDU parsing. ([#308](https://github.com/bgpkit/bgpkit-parser/pull/308))
@@ -22,6 +25,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+* **`BgpValidationWarning` is now `#[non_exhaustive]`**: Exhaustive `match` on this enum must add a `_` arm. This allows new warning variants to be added in future minor releases without breaking downstream matches.
+* **NLRI parse errors are now non-fatal**: `parse_bgp_update_message` previously returned `Err` on any malformed NLRI byte, discarding all attributes and partially-parsed prefixes. It now returns `Ok` with partial data and a `BgpValidationWarning::MalformedNlri`. This is the correct RFC 7606 behavior — callers should check `attributes.validation_warnings()` if they need to distinguish clean updates from partially-recovered ones.
 * **Examples documentation**: Expanded `examples/README.md` to index all maintained Rust, standalone, and WebAssembly examples. Refreshed standalone example instructions, corrected the RIB entry age study path, and made selected archive examples accept input sources or archive months.
 
 ## v0.18.0 - 2026-07-02

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,7 @@ This directory contains runnable examples for bgpkit_parser. They demonstrate ba
 
 ## Error Handling and Robustness
 - [fallible_parsing.rs](fallible_parsing.rs) — Demonstrate fallible record/element iterators that let you handle parse errors explicitly while continuing to process.
+- [treat_as_withdrawal.rs](treat_as_withdrawal.rs) — Scan MRT files for RFC 7606 validation issues (malformed NLRI, bad attributes) and classify them by error-handling category: attribute discard vs. treat-as-withdrawal.
 
 ## Debugging and Analysis
 - [mrt_debug.rs](mrt_debug.rs) — Demonstrate MRT debugging features: debug display for MRT records, raw byte export, and the new `Display` implementation.

--- a/examples/treat_as_withdrawal.rs
+++ b/examples/treat_as_withdrawal.rs
@@ -1,0 +1,180 @@
+//! # RFC 7606 Treat-as-Withdrawal Emulation
+//!
+//! This example demonstrates how to detect malformed BGP UPDATE messages and
+//! apply RFC 7606 "treat-as-withdrawal" semantics using bgpkit-parser's
+//! validation warning system.
+//!
+//! RFC 7606 defines two error-handling approaches for malformed UPDATE messages:
+//!
+//! - **attribute discard**: discard the offending attribute, keep the route
+//! - **treat-as-withdrawal**: withdraw all routes carried in the UPDATE
+//!
+//! bgpkit-parser automatically applies "attribute discard" for bad optional
+//! transitive attributes. For malformed NLRI (RFC 7606 §5.3), the parser
+//! records a [`BgpValidationWarning::MalformedNlri`] and returns the UPDATE
+//! with empty prefix lists. The caller decides whether to also withdraw
+//! previously-installed routes that may have been in the malformed NLRI.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example treat_as_withdrawal --features="local"
+//! ```
+
+use bgpkit_parser::error::BgpValidationWarning;
+use bgpkit_parser::models::{Bgp4MpEnum, BgpMessage, MrtMessage};
+use bgpkit_parser::BgpkitParser;
+
+fn main() {
+    // Use a real MRT updates file. Replace with a URL to a file containing
+    // malformed messages, or use a known-good file to see the "no warnings"
+    // path. For a real incident investigation, point this at the collector
+    // and time window where session resets were observed.
+    let url = "https://data.ris.ripe.net/rrc00/2026.07/updates.20260727.0000.gz";
+
+    println!("Scanning {} for RFC 7606 validation issues...\n", url);
+
+    let parser = match BgpkitParser::new(url) {
+        Ok(p) => p.disable_warnings(),
+        Err(e) => {
+            eprintln!("Failed to create parser: {}", e);
+            return;
+        }
+    };
+
+    let mut total_records = 0u64;
+    let mut records_with_warnings = 0u64;
+    let mut treat_as_withdrawal_count = 0u64;
+    let mut attribute_discard_count = 0u64;
+
+    for result in parser.into_fallible_record_iter() {
+        match result {
+            Ok(record) => {
+                total_records += 1;
+
+                // Extract validation warnings from the BGP UPDATE message
+                let warnings = extract_validation_warnings(&record);
+
+                if warnings.is_empty() {
+                    continue;
+                }
+
+                records_with_warnings += 1;
+
+                // Classify each warning by RFC 7606 error-handling category
+                let has_taw = warnings
+                    .iter()
+                    .any(|w| matches!(w, BgpValidationWarning::MalformedNlri { .. }));
+
+                let has_attr_discard = warnings.iter().any(|w| {
+                    matches!(
+                        w,
+                        BgpValidationWarning::PartialAttributeError { .. }
+                            | BgpValidationWarning::OptionalAttributeError { .. }
+                    )
+                });
+
+                if has_taw {
+                    treat_as_withdrawal_count += 1;
+                    println!("--- TREAT-AS-WITHDRAWAL (record #{}) ---", total_records);
+
+                    for w in warnings {
+                        if let BgpValidationWarning::MalformedNlri {
+                            nlri_type,
+                            reason,
+                            raw_bytes,
+                        } = w
+                        {
+                            println!("  Malformed NLRI ({}): {}", nlri_type, reason);
+                            println!(
+                                "  Raw NLRI bytes ({} bytes): {:02x?}",
+                                raw_bytes.len(),
+                                &raw_bytes[..raw_bytes.len().min(32)]
+                            );
+                            println!("  → All routes in this UPDATE treated as withdrawn");
+                        }
+                    }
+                }
+
+                if has_attr_discard {
+                    attribute_discard_count += 1;
+                    if !has_taw {
+                        println!("--- ATTRIBUTE DISCARD (record #{}) ---", total_records);
+                    }
+                    for w in warnings {
+                        match w {
+                            BgpValidationWarning::PartialAttributeError { attr_type, reason } => {
+                                println!("  Partial attribute error {:?}: {}", attr_type, reason);
+                                println!("  → Attribute discarded, route retained");
+                            }
+                            BgpValidationWarning::OptionalAttributeError { attr_type, reason } => {
+                                println!("  Optional attribute error {:?}: {}", attr_type, reason);
+                                println!("  → Attribute discarded, route retained");
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                // Report structural warnings (missing mandatory, malformed AS_PATH, etc.)
+                for w in warnings {
+                    if !matches!(
+                        w,
+                        BgpValidationWarning::MalformedNlri { .. }
+                            | BgpValidationWarning::PartialAttributeError { .. }
+                            | BgpValidationWarning::OptionalAttributeError { .. }
+                    ) {
+                        println!("  Other validation warning: {}", w);
+                    }
+                }
+            }
+            Err(e) => {
+                total_records += 1;
+                // Parse error: the record could not be parsed at all.
+                // Raw bytes may be available for forensic analysis.
+                if let Some(bytes) = &e.bytes {
+                    eprintln!(
+                        "Record #{}: FATAL parse error: {} ({} raw bytes preserved)",
+                        total_records,
+                        e,
+                        bytes.len()
+                    );
+                } else {
+                    eprintln!("Record #{}: FATAL parse error: {}", total_records, e);
+                }
+            }
+        }
+    }
+
+    println!("\n=== Summary ===");
+    println!("Total records scanned: {}", total_records);
+    println!(
+        "Records with validation warnings: {}",
+        records_with_warnings
+    );
+    println!(
+        "  - Treat-as-withdrawal (malformed NLRI): {}",
+        treat_as_withdrawal_count
+    );
+    println!(
+        "  - Attribute discard (bad optional attr): {}",
+        attribute_discard_count
+    );
+}
+
+/// Extract validation warnings from an MrtRecord by drilling into the
+/// BGP UPDATE message's attributes.
+fn extract_validation_warnings(
+    record: &bgpkit_parser::models::MrtRecord,
+) -> &[BgpValidationWarning] {
+    let bgp_message = match &record.message {
+        MrtMessage::Bgp4Mp(Bgp4MpEnum::Message(msg)) => &msg.bgp_message,
+        _ => return &[],
+    };
+
+    let update = match bgp_message {
+        BgpMessage::Update(u) => u,
+        _ => return &[],
+    };
+
+    update.attributes.validation_warnings()
+}

--- a/examples/treat_as_withdrawal.rs
+++ b/examples/treat_as_withdrawal.rs
@@ -1,19 +1,36 @@
-//! # RFC 7606 Treat-as-Withdrawal Emulation
+//! # RFC 7606 Treat-as-Withdrawal and Junos-style Error Classification
 //!
 //! This example demonstrates how to detect malformed BGP UPDATE messages and
-//! apply RFC 7606 "treat-as-withdrawal" semantics using bgpkit-parser's
-//! validation warning system.
+//! apply RFC 7606 error-handling semantics using bgpkit-parser's validation
+//! warning system. It classifies messages into the three severity tiers used
+//! by Junos OS `bgp-error-tolerance`, applying the "most severe wins" rule.
 //!
-//! RFC 7606 defines two error-handling approaches for malformed UPDATE messages:
+//! ## Three-tier error handling (Junos model)
 //!
-//! - **attribute discard**: discard the offending attribute, keep the route
-//! - **treat-as-withdrawal**: withdraw all routes carried in the UPDATE
+//! 1. **Notification** (session reset): the most severe. Triggered by
+//!    malformed MP_REACH/MP_UNREACH, unparseable NLRI, or attribute
+//!    length/value mismatch. The BGP session is reset.
 //!
-//! bgpkit-parser automatically applies "attribute discard" for bad optional
-//! transitive attributes. For malformed NLRI (RFC 7606 §5.3), the parser
-//! records a [`BgpValidationWarning::MalformedNlri`] and returns the UPDATE
-//! with empty prefix lists. The caller decides whether to also withdraw
-//! previously-installed routes that may have been in the malformed NLRI.
+//! 2. **Treat-as-withdrawal**: all routes in the UPDATE are withdrawn.
+//!    Triggered by malformed well-known mandatory attributes (ORIGIN,
+//!    AS_PATH, NEXT_HOP), plus LOCAL_PREF, MED, communities, and others.
+//!
+//! 3. **Attribute discard**: the bad attribute is dropped, route retained.
+//!    Triggered by malformed optional transitive attributes (AS4_PATH,
+//!    AGGREGATOR, AS4_AGGREGATOR, ATOMIC_AGGREGATE) and duplicate attributes.
+//!
+//! When multiple attributes are malformed in one UPDATE, the **most severe**
+//! approach triggered by any single attribute is applied to the entire message.
+//!
+//! ## Important caveats
+//!
+//! - bgpkit-parser parses MRT data (offline captures), not live sessions. It
+//!   provides the detection signals; this example applies the classification
+//!   policy that a router like Junos would apply.
+//! - bgpkit-parser always recovers what it can: framing errors are fatal, but
+//!   bad NLRI and bad attributes produce warnings + partial data. A real
+//!   router additionally *acts* on the classification (hide route, reset
+//!   session, etc.).
 //!
 //! Run with:
 //! ```sh
@@ -21,17 +38,159 @@
 //! ```
 
 use bgpkit_parser::error::BgpValidationWarning;
-use bgpkit_parser::models::{Bgp4MpEnum, BgpMessage, MrtMessage};
+use bgpkit_parser::models::{AttrType, Bgp4MpEnum, BgpMessage, MrtMessage};
 use bgpkit_parser::BgpkitParser;
 
+/// Severity tiers in decreasing order of severity (Junos model).
+/// When multiple attributes are malformed, the most severe tier wins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ErrorTier {
+    /// Session reset (fatal). MP_REACH/MP_UNREACH malformed, unparseable NLRI.
+    Notification,
+    /// Withdraw all routes in the UPDATE. Bad mandatory + some optional attrs.
+    TreatAsWithdrawal,
+    /// Drop the bad attribute, keep the route. Bad optional transitive attrs.
+    AttributeDiscard,
+}
+
+/// Classify a single validation warning into a severity tier and human-readable
+/// attribute name, following the Junos per-attribute mapping.
+fn classify_warning(w: &BgpValidationWarning) -> Option<(ErrorTier, &'static str)> {
+    match w {
+        // --- Notification level ---
+        // Malformed NLRI: Junos treats unparseable NLRI as notification-level.
+        BgpValidationWarning::MalformedNlri { .. } => Some((ErrorTier::Notification, "NLRI")),
+        // Malformed attribute list (well-known mandatory parse failure):
+        // Junos treats these as notification-level (can't parse the UPDATE).
+        BgpValidationWarning::MalformedAttributeList { .. } => {
+            Some((ErrorTier::Notification, "attribute list"))
+        }
+        // Missing well-known mandatory: if ORIGIN, AS_PATH, or NEXT_HOP is
+        // missing, Junos uses treat-as-withdrawal.
+        BgpValidationWarning::MissingWellKnownAttribute { attr_type } => {
+            Some((ErrorTier::TreatAsWithdrawal, attr_label(*attr_type)))
+        }
+        // --- Treat-as-withdrawal level ---
+        BgpValidationWarning::InvalidOriginAttribute { .. } => {
+            Some((ErrorTier::TreatAsWithdrawal, "ORIGIN"))
+        }
+        BgpValidationWarning::MalformedAsPath { .. } => {
+            Some((ErrorTier::TreatAsWithdrawal, "AS_PATH"))
+        }
+        BgpValidationWarning::InvalidNextHopAttribute { .. } => {
+            Some((ErrorTier::TreatAsWithdrawal, "NEXT_HOP"))
+        }
+        // Partial attribute errors for well-known mandatory attrs → TAW
+        BgpValidationWarning::PartialAttributeError { attr_type, .. } => {
+            let tier = if is_taw_attribute(*attr_type) {
+                ErrorTier::TreatAsWithdrawal
+            } else {
+                ErrorTier::AttributeDiscard
+            };
+            Some((tier, attr_label(*attr_type)))
+        }
+        BgpValidationWarning::OptionalAttributeError { attr_type, .. } => {
+            let tier = if is_taw_attribute(*attr_type) {
+                ErrorTier::TreatAsWithdrawal
+            } else {
+                ErrorTier::AttributeDiscard
+            };
+            Some((tier, attr_label(*attr_type)))
+        }
+        // --- Attribute discard level ---
+        // These attributes get "attribute discard" treatment in Junos
+        BgpValidationWarning::AttributeFlagsError { attr_type, .. } => {
+            let tier = if is_taw_attribute(*attr_type) {
+                ErrorTier::TreatAsWithdrawal
+            } else {
+                ErrorTier::AttributeDiscard
+            };
+            Some((tier, attr_label(*attr_type)))
+        }
+        BgpValidationWarning::AttributeLengthError { attr_type, .. } => {
+            let tier = if is_taw_attribute(*attr_type) {
+                ErrorTier::TreatAsWithdrawal
+            } else {
+                ErrorTier::AttributeDiscard
+            };
+            Some((tier, attr_label(*attr_type)))
+        }
+        BgpValidationWarning::DuplicateAttribute { attr_type } => {
+            // Junos: duplicate attributes → discard all but the first
+            Some((ErrorTier::AttributeDiscard, attr_label(*attr_type)))
+        }
+        // Structural issues
+        BgpValidationWarning::InvalidNetworkField { .. } => {
+            Some((ErrorTier::TreatAsWithdrawal, "network field"))
+        }
+        BgpValidationWarning::UnrecognizedWellKnownAttribute { .. } => {
+            Some((ErrorTier::Notification, "unrecognized well-known"))
+        } // Partial attribute for optional transitive → attribute discard
+        _ => None,
+    }
+}
+
+/// Attributes that trigger treat-as-withdrawal in Junos when malformed.
+/// Everything else with a validation warning defaults to attribute discard.
+fn is_taw_attribute(attr_type: AttrType) -> bool {
+    matches!(
+        attr_type,
+        AttrType::ORIGIN
+            | AttrType::AS_PATH
+            | AttrType::NEXT_HOP
+            | AttrType::MULTI_EXIT_DISCRIMINATOR
+            | AttrType::LOCAL_PREFERENCE
+            | AttrType::COMMUNITIES
+            | AttrType::EXTENDED_COMMUNITIES
+            | AttrType::ORIGINATOR_ID
+            | AttrType::CLUSTER_LIST
+            | AttrType::AIGP
+            | AttrType::PMSI_TUNNEL
+            | AttrType::ATTR_SET
+    )
+}
+
+/// Human-readable attribute name for display.
+fn attr_label(attr_type: AttrType) -> &'static str {
+    match attr_type {
+        AttrType::ORIGIN => "ORIGIN",
+        AttrType::AS_PATH => "AS_PATH",
+        AttrType::NEXT_HOP => "NEXT_HOP",
+        AttrType::MULTI_EXIT_DISCRIMINATOR => "MULTI_EXIT_DISC",
+        AttrType::LOCAL_PREFERENCE => "LOCAL_PREF",
+        AttrType::ATOMIC_AGGREGATE => "ATOMIC_AGGREGATE",
+        AttrType::AGGREGATOR => "AGGREGATOR",
+        AttrType::COMMUNITIES => "COMMUNITIES",
+        AttrType::ORIGINATOR_ID => "ORIGINATOR_ID",
+        AttrType::CLUSTER_LIST => "CLUSTER_LIST",
+        AttrType::MP_REACHABLE_NLRI => "MP_REACH_NLRI",
+        AttrType::MP_UNREACHABLE_NLRI => "MP_UNREACH_NLRI",
+        AttrType::EXTENDED_COMMUNITIES => "EXT_COMMUNITIES",
+        AttrType::AS4_PATH => "AS4_PATH",
+        AttrType::AS4_AGGREGATOR => "AS4_AGGREGATOR",
+        AttrType::AIGP => "AIGP",
+        AttrType::PMSI_TUNNEL => "PMSI_TUNNEL",
+        AttrType::ATTR_SET => "ATTR_SET",
+        AttrType::ONLY_TO_CUSTOMER => "OTC",
+        _ => "UNKNOWN",
+    }
+}
+
+fn tier_label(tier: ErrorTier) -> &'static str {
+    match tier {
+        ErrorTier::Notification => "NOTIFICATION (session reset)",
+        ErrorTier::TreatAsWithdrawal => "TREAT-AS-WITHDRAWAL",
+        ErrorTier::AttributeDiscard => "ATTRIBUTE DISCARD",
+    }
+}
+
 fn main() {
-    // Use a real MRT updates file. Replace with a URL to a file containing
-    // malformed messages, or use a known-good file to see the "no warnings"
-    // path. For a real incident investigation, point this at the collector
-    // and time window where session resets were observed.
+    // Point this at a collector and time window where malformed messages
+    // are suspected. For the Qrator OTC incident, look for UPDATEs from
+    // the affected ASes during the incident window.
     let url = "https://data.ris.ripe.net/rrc00/2026.07/updates.20260727.0000.gz";
 
-    println!("Scanning {} for RFC 7606 validation issues...\n", url);
+    println!("Scanning {} for BGP error-handling issues...\n", url);
 
     let parser = match BgpkitParser::new(url) {
         Ok(p) => p.disable_warnings(),
@@ -42,127 +201,98 @@ fn main() {
     };
 
     let mut total_records = 0u64;
-    let mut records_with_warnings = 0u64;
-    let mut treat_as_withdrawal_count = 0u64;
-    let mut attribute_discard_count = 0u64;
+    let mut records_with_issues = 0u64;
+    let mut by_tier = [0u64; 3]; // [notification, taw, attr_discard]
 
     for result in parser.into_fallible_record_iter() {
         match result {
             Ok(record) => {
                 total_records += 1;
 
-                // Extract validation warnings from the BGP UPDATE message
                 let warnings = extract_validation_warnings(&record);
-
                 if warnings.is_empty() {
                     continue;
                 }
+                records_with_issues += 1;
 
-                records_with_warnings += 1;
-
-                // Classify each warning by RFC 7606 error-handling category
-                let has_taw = warnings
+                // Classify each warning and find the most severe tier
+                // (Junos "most severe wins" rule)
+                let findings: Vec<(ErrorTier, &str, &BgpValidationWarning)> = warnings
                     .iter()
-                    .any(|w| matches!(w, BgpValidationWarning::MalformedNlri { .. }));
+                    .filter_map(|w| classify_warning(w).map(|(t, name)| (t, name, w)))
+                    .collect();
 
-                let has_attr_discard = warnings.iter().any(|w| {
-                    matches!(
-                        w,
-                        BgpValidationWarning::PartialAttributeError { .. }
-                            | BgpValidationWarning::OptionalAttributeError { .. }
-                    )
-                });
-
-                if has_taw {
-                    treat_as_withdrawal_count += 1;
-                    println!("--- TREAT-AS-WITHDRAWAL (record #{}) ---", total_records);
-
-                    for w in warnings {
-                        if let BgpValidationWarning::MalformedNlri {
-                            nlri_type,
-                            reason,
-                            raw_bytes,
-                        } = w
-                        {
-                            println!("  Malformed NLRI ({}): {}", nlri_type, reason);
-                            println!(
-                                "  Raw NLRI bytes ({} bytes): {:02x?}",
-                                raw_bytes.len(),
-                                &raw_bytes[..raw_bytes.len().min(32)]
-                            );
-                            println!("  → All routes in this UPDATE treated as withdrawn");
-                        }
-                    }
+                if findings.is_empty() {
+                    continue;
                 }
 
-                if has_attr_discard {
-                    attribute_discard_count += 1;
-                    if !has_taw {
-                        println!("--- ATTRIBUTE DISCARD (record #{}) ---", total_records);
-                    }
-                    for w in warnings {
-                        match w {
-                            BgpValidationWarning::PartialAttributeError { attr_type, reason } => {
-                                println!("  Partial attribute error {:?}: {}", attr_type, reason);
-                                println!("  → Attribute discarded, route retained");
-                            }
-                            BgpValidationWarning::OptionalAttributeError { attr_type, reason } => {
-                                println!("  Optional attribute error {:?}: {}", attr_type, reason);
-                                println!("  → Attribute discarded, route retained");
-                            }
-                            _ => {}
-                        }
-                    }
-                }
+                // Most severe tier for this record (min ordinal = most severe)
+                let overall_tier = findings.iter().map(|(t, _, _)| *t).min().unwrap();
+                by_tier[overall_tier as usize] += 1;
 
-                // Report structural warnings (missing mandatory, malformed AS_PATH, etc.)
-                for w in warnings {
-                    if !matches!(
-                        w,
-                        BgpValidationWarning::MalformedNlri { .. }
-                            | BgpValidationWarning::PartialAttributeError { .. }
-                            | BgpValidationWarning::OptionalAttributeError { .. }
-                    ) {
-                        println!("  Other validation warning: {}", w);
+                println!(
+                    "--- {} (record #{}) ---",
+                    tier_label(overall_tier),
+                    total_records
+                );
+
+                for (tier, name, warning) in &findings {
+                    let marker = if *tier == overall_tier { "→" } else { " " };
+                    let action = match tier {
+                        ErrorTier::Notification => "session reset",
+                        ErrorTier::TreatAsWithdrawal => "routes withdrawn",
+                        ErrorTier::AttributeDiscard => "attribute discarded",
+                    };
+                    println!("  {marker} [{name}] {warning}");
+                    println!("    action: {action}");
+
+                    // Show raw NLRI bytes if available
+                    if let BgpValidationWarning::MalformedNlri { raw_bytes, .. } = warning {
+                        let display_len = raw_bytes.len().min(32);
+                        println!(
+                            "    raw NLRI ({} bytes): {:02x?}",
+                            display_len,
+                            &raw_bytes[..display_len]
+                        );
                     }
                 }
+                println!();
             }
             Err(e) => {
                 total_records += 1;
-                // Parse error: the record could not be parsed at all.
-                // Raw bytes may be available for forensic analysis.
+                by_tier[ErrorTier::Notification as usize] += 1;
                 if let Some(bytes) = &e.bytes {
                     eprintln!(
-                        "Record #{}: FATAL parse error: {} ({} raw bytes preserved)",
+                        "Record #{}: FATAL ({} raw bytes preserved): {}",
                         total_records,
-                        e,
-                        bytes.len()
+                        bytes.len(),
+                        e
                     );
                 } else {
-                    eprintln!("Record #{}: FATAL parse error: {}", total_records, e);
+                    eprintln!("Record #{}: FATAL: {}", total_records, e);
                 }
             }
         }
     }
 
-    println!("\n=== Summary ===");
+    println!("=== Summary ===");
     println!("Total records scanned: {}", total_records);
+    println!("Records with issues: {}", records_with_issues);
     println!(
-        "Records with validation warnings: {}",
-        records_with_warnings
+        "  Notification (session reset): {}",
+        by_tier[ErrorTier::Notification as usize]
     );
     println!(
-        "  - Treat-as-withdrawal (malformed NLRI): {}",
-        treat_as_withdrawal_count
+        "  Treat-as-withdrawal:          {}",
+        by_tier[ErrorTier::TreatAsWithdrawal as usize]
     );
     println!(
-        "  - Attribute discard (bad optional attr): {}",
-        attribute_discard_count
+        "  Attribute discard:            {}",
+        by_tier[ErrorTier::AttributeDiscard as usize]
     );
 }
 
-/// Extract validation warnings from an MrtRecord by drilling into the
-/// BGP UPDATE message's attributes.
+/// Extract validation warnings from an MrtRecord.
 fn extract_validation_warnings(
     record: &bgpkit_parser::models::MrtRecord,
 ) -> &[BgpValidationWarning] {
@@ -171,10 +301,8 @@ fn extract_validation_warnings(
         _ => return &[],
     };
 
-    let update = match bgp_message {
-        BgpMessage::Update(u) => u,
-        _ => return &[],
-    };
-
-    update.attributes.validation_warnings()
+    match bgp_message {
+        BgpMessage::Update(u) => u.attributes.validation_warnings(),
+        _ => &[],
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,7 +154,11 @@ impl From<TryFromPrimitiveError<Safi>> for ParserError {
 
 /// BGP validation warnings for RFC 7606 compliant error handling.
 /// These represent non-fatal validation issues that don't prevent parsing.
+///
+/// This enum is `#[non_exhaustive]` so that new warning variants can be added
+/// in minor releases without breaking exhaustive matches.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BgpValidationWarning {
     /// Attribute flags conflict with attribute type code (RFC 4271 Section 6.3)
     AttributeFlagsError {
@@ -188,6 +192,23 @@ pub enum BgpValidationWarning {
     MalformedAttributeList { reason: String },
     /// Partial attribute with errors (RFC 7606)
     PartialAttributeError { attr_type: AttrType, reason: String },
+    /// Malformed NLRI field (RFC 7606 §5.3). The UPDATE message was parseable
+    /// up to the NLRI section, but the NLRI itself contained syntactic errors.
+    /// Per RFC 7606, the recommended action is "treat-as-withdrawal": all
+    /// routes carried in the NLRI section should be withdrawn.
+    ///
+    /// `nlri_type` distinguishes between the standard (IPv4 unicast) NLRI
+    /// field and the multiprotocol NLRI carried inside MP_REACH/MP_UNREACH
+    /// path attributes. `raw_bytes` preserves the offending NLRI bytes so
+    /// callers can inspect or export them without re-encoding.
+    MalformedNlri {
+        /// "withdrawn", "announced", "mp_reach", or "mp_unreach"
+        nlri_type: &'static str,
+        /// Human-readable description of the parse error
+        reason: String,
+        /// Raw NLRI bytes as they appeared in the UPDATE message
+        raw_bytes: Vec<u8>,
+    },
 }
 
 impl Display for BgpValidationWarning {
@@ -231,6 +252,9 @@ impl Display for BgpValidationWarning {
             }
             BgpValidationWarning::PartialAttributeError { attr_type, reason } => {
                 write!(f, "Partial attribute error for {attr_type:?}: {reason}")
+            }
+            BgpValidationWarning::MalformedNlri { nlri_type, reason, .. } => {
+                write!(f, "Malformed NLRI ({nlri_type}): {reason}")
             }
         }
     }

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -495,6 +495,7 @@ pub fn parse_bgp_update_message(
 
     // parse announced prefixes nlri.
     // the remaining bytes are announced prefixes.
+    let announced_bytes_present = !input.is_empty();
     let (announced_prefixes, announced_nlri_error) = match read_nlri(input.clone(), &afi, add_path)
     {
         Ok(pfxs) => (pfxs, None),
@@ -508,10 +509,14 @@ pub fn parse_bgp_update_message(
         ),
     };
 
-    // validate mandatory attributes
+    // validate mandatory attributes.
+    // Use `announced_bytes_present` (wire-level) rather than
+    // `!announced_prefixes.is_empty()` (parse result) so that a malformed
+    // NLRI section still triggers mandatory-attribute validation — the
+    // UPDATE clearly intended to announce routes.
     let is_announcement =
-        !announced_prefixes.is_empty() || attributes.has_attr(AttrType::MP_REACHABLE_NLRI);
-    let has_standard_nlri = !announced_prefixes.is_empty();
+        announced_bytes_present || attributes.has_attr(AttrType::MP_REACHABLE_NLRI);
+    let has_standard_nlri = announced_bytes_present;
     attributes.check_mandatory_attributes(is_announcement, has_standard_nlri);
 
     // Attach NLRI parse warnings (RFC 7606 §5.3 treat-as-withdrawal evidence)

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::TryFrom;
 use std::net::Ipv4Addr;
 
-use crate::error::ParserError;
+use crate::error::{BgpValidationWarning, ParserError};
 use crate::models::capabilities::{
     AddPathCapability, BgpCapabilityType, BgpExtendedMessageCapability, BgpRoleCapability,
     ExtendedNextHopCapability, FourOctetAsCapability, GracefulRestartCapability,
@@ -448,6 +448,12 @@ fn read_nlri(
 /// read bgp update message.
 ///
 /// RFC: <https://tools.ietf.org/html/rfc4271#section-4.3>
+///
+/// Per RFC 7606, NLRI parse errors are non-fatal: the message is returned with
+/// partial data and a [`BgpValidationWarning::MalformedNlri`] appended to
+/// `attributes.validation_warnings`. Callers that want RFC 7606 treat-as-withdrawal
+/// semantics can inspect the warnings and act accordingly. Attribute-section
+/// framing errors (wrong length fields, truncated data) remain fatal.
 pub fn parse_bgp_update_message(
     mut input: Bytes,
     add_path: bool,
@@ -461,7 +467,18 @@ pub fn parse_bgp_update_message(
     let withdrawn_bytes_length = withdrawn_bytes_length_raw as usize;
     input.has_n_remaining(withdrawn_bytes_length)?;
     let withdrawn_bytes = input.split_to(withdrawn_bytes_length);
-    let withdrawn_prefixes = read_nlri(withdrawn_bytes, &afi, add_path)?;
+    let (withdrawn_prefixes, withdrawn_nlri_error) =
+        match read_nlri(withdrawn_bytes.clone(), &afi, add_path) {
+            Ok(pfxs) => (pfxs, None),
+            Err(e) => (
+                Vec::new(),
+                Some(BgpValidationWarning::MalformedNlri {
+                    nlri_type: "withdrawn",
+                    reason: e.to_string(),
+                    raw_bytes: withdrawn_bytes.to_vec(),
+                }),
+            ),
+        };
 
     // parse attributes
     let attribute_length_raw = input.read_u16()?;
@@ -476,13 +493,32 @@ pub fn parse_bgp_update_message(
 
     // parse announced prefixes nlri.
     // the remaining bytes are announced prefixes.
-    let announced_prefixes = read_nlri(input, &afi, add_path)?;
+    let (announced_prefixes, announced_nlri_error) = match read_nlri(input.clone(), &afi, add_path)
+    {
+        Ok(pfxs) => (pfxs, None),
+        Err(e) => (
+            Vec::new(),
+            Some(BgpValidationWarning::MalformedNlri {
+                nlri_type: "announced",
+                reason: e.to_string(),
+                raw_bytes: input.to_vec(),
+            }),
+        ),
+    };
 
     // validate mandatory attributes
     let is_announcement =
         !announced_prefixes.is_empty() || attributes.has_attr(AttrType::MP_REACHABLE_NLRI);
     let has_standard_nlri = !announced_prefixes.is_empty();
     attributes.check_mandatory_attributes(is_announcement, has_standard_nlri);
+
+    // Attach NLRI parse warnings (RFC 7606 §5.3 treat-as-withdrawal evidence)
+    if let Some(w) = withdrawn_nlri_error {
+        attributes.add_validation_warning(w);
+    }
+    if let Some(w) = announced_nlri_error {
+        attributes.add_validation_warning(w);
+    }
 
     Ok(BgpUpdateMessage {
         withdrawn_prefixes,

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -426,20 +426,21 @@ impl BgpOpenMessage {
 }
 
 /// read nlri portion of a bgp update message.
-fn read_nlri(
-    mut input: Bytes,
-    afi: &Afi,
-    add_path: bool,
-) -> Result<Vec<NetworkPrefix>, ParserError> {
+///
+/// Returns `Ok(vec![])` for empty NLRI. Returns `Err` for malformed NLRI
+/// (1-byte field, invalid prefix lengths, truncated data), so that the caller
+/// in `parse_bgp_update_message` can convert it to a `MalformedNlri` warning.
+fn read_nlri(input: Bytes, afi: &Afi, add_path: bool) -> Result<Vec<NetworkPrefix>, ParserError> {
     let length = input.len();
     if length == 0 {
         return Ok(vec![]);
     }
     if length == 1 {
-        // 1 byte does not make sense
+        // 1 byte does not make a valid NLRI encoding
         warn!("seeing strange one-byte NLRI field (parsing NLRI in BGP UPDATE message)");
-        input.advance(1); // skip the byte
-        return Ok(vec![]);
+        return Err(ParserError::ParseError(
+            "one-byte NLRI field is not a valid encoding".to_string(),
+        ));
     }
 
     parse_nlri_list(input, add_path, afi)

--- a/src/parser/bgp/messages.rs
+++ b/src/parser/bgp/messages.rs
@@ -428,18 +428,19 @@ impl BgpOpenMessage {
 /// read nlri portion of a bgp update message.
 ///
 /// Returns `Ok(vec![])` for empty NLRI. Returns `Err` for malformed NLRI
-/// (1-byte field, invalid prefix lengths, truncated data), so that the caller
+/// (invalid prefix lengths, truncated data), so that the caller
 /// in `parse_bgp_update_message` can convert it to a `MalformedNlri` warning.
 fn read_nlri(input: Bytes, afi: &Afi, add_path: bool) -> Result<Vec<NetworkPrefix>, ParserError> {
     let length = input.len();
     if length == 0 {
         return Ok(vec![]);
     }
-    if length == 1 {
-        // 1 byte does not make a valid NLRI encoding
+    if length == 1 && input[0] != 0 {
+        // A single non-zero byte cannot be a valid NLRI: a valid 1-byte NLRI
+        // encodes only the default route (prefix length 0, no prefix octets).
         warn!("seeing strange one-byte NLRI field (parsing NLRI in BGP UPDATE message)");
         return Err(ParserError::ParseError(
-            "one-byte NLRI field is not a valid encoding".to_string(),
+            "one-byte NLRI field with non-zero value is not a valid encoding".to_string(),
         ));
     }
 

--- a/src/parser/mrt/mrt_record.rs
+++ b/src/parser/mrt/mrt_record.rs
@@ -165,13 +165,21 @@ pub fn chunk_mrt_record(input: &mut impl Read) -> Result<RawMrtRecord, ParserErr
 
 pub fn parse_mrt_record(input: &mut impl Read) -> Result<MrtRecord, ParserErrorWithBytes> {
     let raw_record = chunk_mrt_record(input)?;
-    let raw_bytes = raw_record.raw_bytes();
+    // Capture raw bytes before parse() consumes raw_record.
+    let header_bytes = raw_record.header_bytes.clone();
+    let message_bytes = raw_record.message_bytes.clone();
     match raw_record.parse() {
         Ok(record) => Ok(record),
-        Err(e) => Err(ParserErrorWithBytes {
-            error: e,
-            bytes: Some(raw_bytes.to_vec()),
-        }),
+        Err(e) => {
+            // Build the raw bytes Vec directly from header + message bytes.
+            let mut bytes = Vec::with_capacity(header_bytes.len() + message_bytes.len());
+            bytes.extend_from_slice(&header_bytes);
+            bytes.extend_from_slice(&message_bytes);
+            Err(ParserErrorWithBytes {
+                error: e,
+                bytes: Some(bytes),
+            })
+        }
     }
 }
 

--- a/src/parser/mrt/mrt_record.rs
+++ b/src/parser/mrt/mrt_record.rs
@@ -165,11 +165,12 @@ pub fn chunk_mrt_record(input: &mut impl Read) -> Result<RawMrtRecord, ParserErr
 
 pub fn parse_mrt_record(input: &mut impl Read) -> Result<MrtRecord, ParserErrorWithBytes> {
     let raw_record = chunk_mrt_record(input)?;
+    let raw_bytes = raw_record.raw_bytes();
     match raw_record.parse() {
         Ok(record) => Ok(record),
         Err(e) => Err(ParserErrorWithBytes {
             error: e,
-            bytes: None,
+            bytes: Some(raw_bytes.to_vec()),
         }),
     }
 }

--- a/src/parser/mrt/mrt_record.rs
+++ b/src/parser/mrt/mrt_record.rs
@@ -165,21 +165,14 @@ pub fn chunk_mrt_record(input: &mut impl Read) -> Result<RawMrtRecord, ParserErr
 
 pub fn parse_mrt_record(input: &mut impl Read) -> Result<MrtRecord, ParserErrorWithBytes> {
     let raw_record = chunk_mrt_record(input)?;
-    // Capture raw bytes before parse() consumes raw_record.
-    let header_bytes = raw_record.header_bytes.clone();
-    let message_bytes = raw_record.message_bytes.clone();
-    match raw_record.parse() {
+    // Parse from a clone so the original is available for raw_bytes() on error,
+    // avoiding manual reassembly that could diverge from RawMrtRecord::raw_bytes().
+    match raw_record.clone().parse() {
         Ok(record) => Ok(record),
-        Err(e) => {
-            // Build the raw bytes Vec directly from header + message bytes.
-            let mut bytes = Vec::with_capacity(header_bytes.len() + message_bytes.len());
-            bytes.extend_from_slice(&header_bytes);
-            bytes.extend_from_slice(&message_bytes);
-            Err(ParserErrorWithBytes {
-                error: e,
-                bytes: Some(bytes),
-            })
-        }
+        Err(e) => Err(ParserErrorWithBytes {
+            error: e,
+            bytes: Some(raw_record.raw_bytes().to_vec()),
+        }),
     }
 }
 

--- a/tests/test_rfc7606_error_handling.rs
+++ b/tests/test_rfc7606_error_handling.rs
@@ -362,3 +362,36 @@ fn test_parser_error_with_bytes_display() {
     let display = format!("{}", err);
     assert!(display.contains("test error"));
 }
+
+// ========================================================================
+// Test 12: 1-byte NLRI field is now treated as malformed (was silently
+//          skipped before — Copilot review comment on PR #309)
+// ========================================================================
+
+#[test]
+fn test_one_byte_nlri_produces_warning_not_silent_skip() {
+    let asn_len = AsnLength::Bits32;
+
+    // A 1-byte NLRI field in the announced section — previously this was
+    // silently skipped (Ok(vec![])), now it produces a MalformedNlri warning.
+    let one_byte_nlri = vec![0xFF];
+    let body = build_update_body(&[], &build_valid_attrs(), &one_byte_nlri);
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    assert!(update.announced_prefixes.is_empty());
+    assert!(
+        update.attributes.has_validation_warnings(),
+        "1-byte NLRI should produce a MalformedNlri warning"
+    );
+    assert!(update
+        .attributes
+        .validation_warnings()
+        .iter()
+        .any(|w| matches!(
+            w,
+            BgpValidationWarning::MalformedNlri {
+                nlri_type: "announced",
+                ..
+            }
+        )));
+}

--- a/tests/test_rfc7606_error_handling.rs
+++ b/tests/test_rfc7606_error_handling.rs
@@ -420,3 +420,67 @@ fn test_one_byte_nlri_default_route_is_valid() {
         "valid default route NLRI must not produce warnings"
     );
 }
+
+// ========================================================================
+// Test 14: Malformed announced NLRI still triggers mandatory-attr validation
+//         (Copilot review: is_announcement must reflect wire-level NLRI
+//         presence, not parse success)
+// ========================================================================
+
+#[test]
+fn test_malformed_nlri_still_triggers_mandatory_attr_check() {
+    let asn_len = AsnLength::Bits32;
+
+    // Build an UPDATE with malformed announced NLRI but NO mandatory
+    // attributes (no ORIGIN, no AS_PATH, no NEXT_HOP). The mandatory-attr
+    // check should still fire because the UPDATE clearly intended to
+    // announce routes (NLRI bytes were present on the wire).
+    let malformed_nlri = vec![0xC8, 0x01];
+    let body = build_update_body(&[], &[], &malformed_nlri);
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    let warnings = update.attributes.validation_warnings();
+
+    // Should have MalformedNlri
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MalformedNlri {
+                nlri_type: "announced",
+                ..
+            }
+        )),
+        "expected MalformedNlri warning"
+    );
+
+    // Should ALSO have missing mandatory attribute warnings — the UPDATE
+    // carried NLRI bytes (intent to announce) but lacked ORIGIN/AS_PATH/NEXT_HOP
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MissingWellKnownAttribute {
+                attr_type: AttrType::ORIGIN
+            }
+        )),
+        "expected MissingWellKnownAttribute(ORIGIN) — mandatory check must fire even with malformed NLRI, got: {:?}",
+        warnings
+    );
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MissingWellKnownAttribute {
+                attr_type: AttrType::AS_PATH
+            }
+        )),
+        "expected MissingWellKnownAttribute(AS_PATH)"
+    );
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MissingWellKnownAttribute {
+                attr_type: AttrType::NEXT_HOP
+            }
+        )),
+        "expected MissingWellKnownAttribute(NEXT_HOP)"
+    );
+}

--- a/tests/test_rfc7606_error_handling.rs
+++ b/tests/test_rfc7606_error_handling.rs
@@ -1,0 +1,364 @@
+//! Tests for RFC 7606 revised error handling: non-fatal NLRI parsing,
+//! raw byte preservation on parse failures, and treat-as-withdrawal support.
+//!
+//! These tests exercise the parser's ability to return partial UPDATE
+//! messages with [`BgpValidationWarning`]s instead of failing hard on
+//! malformed NLRI data.
+
+use bgpkit_parser::error::{BgpValidationWarning, ParserError, ParserErrorWithBytes};
+use bgpkit_parser::models::*;
+use bgpkit_parser::parser::bgp::messages::parse_bgp_update_message;
+use bgpkit_parser::parser::mrt::mrt_record::parse_mrt_record;
+use bytes::Bytes;
+use std::io::Cursor;
+
+/// Build a minimal valid BGP UPDATE message body (the bytes after the
+/// 16-byte marker + 2-byte length + 1-byte type of the BGP message header).
+///
+/// Layout:
+///   u16 withdrawn_length | withdrawn_bytes | u16 attr_length | attr_bytes | nlri
+fn build_update_body(withdrawn: &[u8], attrs: &[u8], nlri: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::new();
+    msg.extend_from_slice(&(withdrawn.len() as u16).to_be_bytes());
+    msg.extend_from_slice(withdrawn);
+    msg.extend_from_slice(&(attrs.len() as u16).to_be_bytes());
+    msg.extend_from_slice(attrs);
+    msg.extend_from_slice(nlri);
+    msg
+}
+
+/// Build minimal attributes: ORIGIN(IGP) + AS_PATH(empty) + NEXT_HOP
+fn build_valid_attrs() -> Vec<u8> {
+    let mut attrs = Vec::new();
+    // ORIGIN = IGP
+    attrs.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]);
+    // AS_PATH = empty
+    attrs.extend_from_slice(&[0x40, 0x02, 0x00]);
+    // NEXT_HOP = 1.2.3.4
+    attrs.extend_from_slice(&[0x40, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04]);
+    attrs
+}
+
+/// A valid NLRI encoding 10.0.0.0/24: prefix_len=24, prefix=0x0A000000 (3 bytes)
+fn valid_nlri_prefix() -> Vec<u8> {
+    vec![0x18, 0x0A, 0x00, 0x00]
+}
+
+/// Malformed NLRI: 2 bytes starting with prefix_len=200 (0xC8), impossible for IPv4.
+/// Must be >= 2 bytes to avoid the 1-byte guard in read_nlri.
+fn malformed_nlri() -> Vec<u8> {
+    vec![0xC8, 0x01]
+}
+
+// ========================================================================
+// Test 1: Malformed announced NLRI produces a warning, not an error
+// ========================================================================
+
+#[test]
+fn test_malformed_announced_nlri_produces_warning_not_error() {
+    let asn_len = AsnLength::Bits32;
+    let body = build_update_body(&[], &build_valid_attrs(), &malformed_nlri());
+    let result = parse_bgp_update_message(Bytes::from(body), false, &asn_len);
+
+    let update = result.expect("malformed NLRI should not be fatal");
+    assert!(
+        update.announced_prefixes.is_empty(),
+        "prefixes should be empty"
+    );
+    assert!(
+        update.attributes.has_validation_warnings(),
+        "should have validation warnings"
+    );
+
+    let warnings = update.attributes.validation_warnings();
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MalformedNlri {
+                nlri_type: "announced",
+                ..
+            }
+        )),
+        "expected MalformedNlri warning for announced NLRI, got: {:?}",
+        warnings
+    );
+}
+
+// ========================================================================
+// Test 2: Malformed NLRI preserves raw bytes in the warning
+// ========================================================================
+
+#[test]
+fn test_malformed_announced_nlri_preserves_raw_bytes_in_warning() {
+    let asn_len = AsnLength::Bits32;
+    let nlri = malformed_nlri();
+    let body = build_update_body(&[], &build_valid_attrs(), &nlri);
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    let warnings = update.attributes.validation_warnings();
+    let nlri_warning = warnings.iter().find_map(|w| match w {
+        BgpValidationWarning::MalformedNlri {
+            nlri_type: "announced",
+            raw_bytes,
+            ..
+        } => Some(raw_bytes),
+        _ => None,
+    });
+    assert_eq!(
+        nlri_warning,
+        Some(&nlri),
+        "raw NLRI bytes should be preserved"
+    );
+}
+
+// ========================================================================
+// Test 3: Malformed withdrawn NLRI produces a warning, not an error
+// ========================================================================
+
+#[test]
+fn test_malformed_withdrawn_nlri_produces_warning_not_error() {
+    let asn_len = AsnLength::Bits32;
+    let body = build_update_body(&malformed_nlri(), &build_valid_attrs(), &[]);
+    let result = parse_bgp_update_message(Bytes::from(body), false, &asn_len);
+
+    let update = result.expect("malformed withdrawn NLRI should not be fatal");
+    assert!(
+        update.withdrawn_prefixes.is_empty(),
+        "withdrawn prefixes should be empty"
+    );
+
+    let warnings = update.attributes.validation_warnings();
+    assert!(
+        warnings.iter().any(|w| matches!(
+            w,
+            BgpValidationWarning::MalformedNlri {
+                nlri_type: "withdrawn",
+                ..
+            }
+        )),
+        "expected MalformedNlri warning for withdrawn NLRI, got: {:?}",
+        warnings
+    );
+}
+
+// ========================================================================
+// Test 4: Attributes survive NLRI parse failure (partial recovery)
+// ========================================================================
+
+#[test]
+fn test_attributes_survive_nlri_parse_failure() {
+    let asn_len = AsnLength::Bits32;
+    let body = build_update_body(&[], &build_valid_attrs(), &malformed_nlri());
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    assert!(update.attributes.has_attr(AttrType::ORIGIN));
+    assert!(update.attributes.has_attr(AttrType::AS_PATH));
+    assert!(update.attributes.has_attr(AttrType::NEXT_HOP));
+}
+
+#[test]
+fn test_valid_withdrawn_survives_malformed_announced_nlri() {
+    let asn_len = AsnLength::Bits32;
+    let body = build_update_body(
+        &valid_nlri_prefix(),
+        &build_valid_attrs(),
+        &malformed_nlri(),
+    );
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    // Withdrawn prefix should survive
+    assert_eq!(update.withdrawn_prefixes.len(), 1);
+    // Announced should be empty (recovered as partial)
+    assert!(
+        update.announced_prefixes.is_empty(),
+        "malformed announced NLRI should produce no prefixes"
+    );
+    assert!(
+        update.attributes.has_validation_warnings(),
+        "should have validation warnings for the malformed announced NLRI"
+    );
+}
+
+// ========================================================================
+// Test 5: Normal valid UPDATE still parses without warnings
+// ========================================================================
+
+#[test]
+fn test_valid_update_still_parses_clean() {
+    let asn_len = AsnLength::Bits32;
+    let body = build_update_body(&[], &build_valid_attrs(), &valid_nlri_prefix());
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    assert_eq!(update.announced_prefixes.len(), 1);
+    assert!(
+        !update.attributes.has_validation_warnings(),
+        "valid UPDATE should have no validation warnings"
+    );
+}
+
+// ========================================================================
+// Test 6: Attribute framing errors are still fatal
+// ========================================================================
+
+#[test]
+fn test_attribute_length_exceeding_available_bytes_is_fatal() {
+    let asn_len = AsnLength::Bits32;
+
+    let mut msg = Vec::new();
+    msg.extend_from_slice(&0x0000u16.to_be_bytes()); // withdrawn length = 0
+    msg.extend_from_slice(&0x03E8u16.to_be_bytes()); // attr length = 1000
+    msg.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]); // only 4 bytes
+
+    let result = parse_bgp_update_message(Bytes::from(msg), false, &asn_len);
+    assert!(result.is_err(), "truncated attribute data should be fatal");
+}
+
+// ========================================================================
+// Test 7: Raw bytes preserved on MRT body-parse failure
+// ========================================================================
+
+#[test]
+fn test_parse_mrt_record_preserves_raw_bytes_on_failure() {
+    // Build an MRT record with entry_type=12 (TABLE_DUMP, a valid type),
+    // but a body that will fail to parse (truncated/invalid for that type).
+    let mut data = Vec::new();
+
+    // MRT common header: timestamp(4) + type(2) + subtype(2) + length(4)
+    data.extend_from_slice(&0x00000000u32.to_be_bytes()); // timestamp
+    data.extend_from_slice(&0x000Cu16.to_be_bytes()); // entry type = 12 (TABLE_DUMP)
+    data.extend_from_slice(&0x0000u16.to_be_bytes()); // subtype
+    data.extend_from_slice(&0x00000004u32.to_be_bytes()); // length = 4
+    data.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]); // invalid body
+
+    let mut cursor = Cursor::new(data);
+    let result = parse_mrt_record(&mut cursor);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.bytes.is_some(),
+        "raw bytes should be preserved on parse failure"
+    );
+    let bytes = err.bytes.unwrap();
+    assert!(!bytes.is_empty(), "preserved bytes should not be empty");
+}
+
+// ========================================================================
+// Test 8: Malformed OTC attribute scenario (Qrator blog incident)
+//
+// An OTC attribute (type 35) with the Extended Length flag incorrectly set.
+// The parser reads a 2-byte length = 0x0400 = 1024, but only 4 bytes of
+// value follow. This mismatch is caught by the attribute error handler.
+// ========================================================================
+
+#[test]
+fn test_malformed_otc_attribute_extended_length_mismatch() {
+    let asn_len = AsnLength::Bits32;
+
+    let mut attrs = build_valid_attrs();
+    attrs.extend_from_slice(&[
+        0xF0, // flags: Optional | Transitive | Partial | Extended Length
+        0x23, // type: 35 = OTC
+        0x04, 0x00, // Extended length: 0x0400 = 1024 bytes claimed
+    ]);
+    attrs.extend_from_slice(&0x0000FE4Cu32.to_be_bytes()); // OTC value = 65100
+
+    let body = build_update_body(&[], &attrs, &valid_nlri_prefix());
+    let result = parse_bgp_update_message(Bytes::from(body), false, &asn_len);
+
+    match result {
+        Ok(update) => {
+            // NLRI should still be present (attribute error does not destroy NLRI)
+            assert_eq!(
+                update.announced_prefixes.len(),
+                1,
+                "NLRI should survive bad optional attribute"
+            );
+            assert!(
+                update.attributes.has_validation_warnings(),
+                "expected validation warnings for malformed OTC attribute"
+            );
+        }
+        Err(e) => panic!("malformed OTC attribute should not be fatal: {}", e),
+    }
+}
+
+// ========================================================================
+// Test 9: Treat-as-withdrawal emulation pattern
+//
+// Demonstrates the caller pattern for detecting malformed NLRI and treating
+// the affected routes as withdrawn per RFC 7606 §5.3.
+// ========================================================================
+
+#[test]
+fn test_treat_as_withdrawal_emulation() {
+    let asn_len = AsnLength::Bits32;
+
+    // Build an UPDATE with valid attributes and malformed announced NLRI
+    let bad_nlri = malformed_nlri();
+    let bad_body = build_update_body(&[], &build_valid_attrs(), &bad_nlri);
+
+    let bad_update = parse_bgp_update_message(Bytes::from(bad_body), false, &asn_len).unwrap();
+
+    // RFC 7606 treat-as-withdrawal: when NLRI is malformed, all routes in
+    // the UPDATE should be treated as withdrawn.
+    let needs_taw = bad_update
+        .attributes
+        .validation_warnings()
+        .iter()
+        .any(|w| matches!(w, BgpValidationWarning::MalformedNlri { .. }));
+
+    assert!(
+        needs_taw,
+        "malformed NLRI should be detectable via warnings"
+    );
+
+    // Caller actions:
+    // 1. Do not install any routes (announced_prefixes is empty)
+    assert!(bad_update.announced_prefixes.is_empty());
+
+    // 2. Raw bytes are available for forensic extraction
+    let raw_nlri = bad_update
+        .attributes
+        .validation_warnings()
+        .iter()
+        .find_map(|w| match w {
+            BgpValidationWarning::MalformedNlri { raw_bytes, .. } => Some(raw_bytes),
+            _ => None,
+        });
+    assert_eq!(
+        raw_nlri,
+        Some(&bad_nlri),
+        "raw NLRI bytes should be available for extraction"
+    );
+}
+
+// ========================================================================
+// Test 10: BgpValidationWarning::MalformedNlri Display formatting
+// ========================================================================
+
+#[test]
+fn test_malformed_nlri_warning_display() {
+    let warning = BgpValidationWarning::MalformedNlri {
+        nlri_type: "announced",
+        reason: "invalid prefix length".to_string(),
+        raw_bytes: vec![0xC8, 0x01],
+    };
+    let display = format!("{}", warning);
+    assert!(display.contains("announced"));
+    assert!(display.contains("invalid prefix length"));
+}
+
+// ========================================================================
+// Test 11: ParserErrorWithBytes Display formatting
+// ========================================================================
+
+#[test]
+fn test_parser_error_with_bytes_display() {
+    let err = ParserErrorWithBytes {
+        error: ParserError::ParseError("test error".to_string()),
+        bytes: Some(vec![0x01, 0x02]),
+    };
+    let display = format!("{}", err);
+    assert!(display.contains("test error"));
+}

--- a/tests/test_rfc7606_error_handling.rs
+++ b/tests/test_rfc7606_error_handling.rs
@@ -364,24 +364,24 @@ fn test_parser_error_with_bytes_display() {
 }
 
 // ========================================================================
-// Test 12: 1-byte NLRI field is now treated as malformed (was silently
-//          skipped before — Copilot review comment on PR #309)
+// Test 12: 1-byte NLRI with invalid prefix length is treated as malformed.
+//          A 1-byte NLRI with value 0x00 (default route /0) is valid and
+//          must NOT be flagged. (Copilot review comment on PR #309)
 // ========================================================================
 
 #[test]
-fn test_one_byte_nlri_produces_warning_not_silent_skip() {
+fn test_one_byte_nlri_invalid_prefix_produces_warning() {
     let asn_len = AsnLength::Bits32;
 
-    // A 1-byte NLRI field in the announced section — previously this was
-    // silently skipped (Ok(vec![])), now it produces a MalformedNlri warning.
-    let one_byte_nlri = vec![0xFF];
-    let body = build_update_body(&[], &build_valid_attrs(), &one_byte_nlri);
+    // A 1-byte NLRI with value 0xFF (prefix length 255) is invalid for IPv4.
+    let invalid_one_byte = vec![0xFF];
+    let body = build_update_body(&[], &build_valid_attrs(), &invalid_one_byte);
     let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
 
     assert!(update.announced_prefixes.is_empty());
     assert!(
         update.attributes.has_validation_warnings(),
-        "1-byte NLRI should produce a MalformedNlri warning"
+        "1-byte NLRI with invalid prefix length should produce a warning"
     );
     assert!(update
         .attributes
@@ -394,4 +394,29 @@ fn test_one_byte_nlri_produces_warning_not_silent_skip() {
                 ..
             }
         )));
+}
+
+// ========================================================================
+// Test 13: 1-byte NLRI encoding default route (0.0.0.0/0) is valid
+// ========================================================================
+
+#[test]
+fn test_one_byte_nlri_default_route_is_valid() {
+    let asn_len = AsnLength::Bits32;
+
+    // A 1-byte NLRI with value 0x00 encodes the default route (prefix
+    // length 0, no prefix octets). This is valid and must parse cleanly.
+    let default_route_nlri = vec![0x00];
+    let body = build_update_body(&[], &build_valid_attrs(), &default_route_nlri);
+    let update = parse_bgp_update_message(Bytes::from(body), false, &asn_len).unwrap();
+
+    assert_eq!(
+        update.announced_prefixes.len(),
+        1,
+        "default route 0.0.0.0/0 should be parsed"
+    );
+    assert!(
+        !update.attributes.has_validation_warnings(),
+        "valid default route NLRI must not produce warnings"
+    );
 }


### PR DESCRIPTION
Closes #303

## Summary

Implements RFC 7606 revised error handling for BGP UPDATE messages, enabling treat-as-withdrawal emulation. Two coupled changes:

### 1. Non-fatal NLRI parsing (`parse_bgp_update_message`)

Previously, any malformed byte in the withdrawn or announced NLRI caused the entire UPDATE to fail — destroying all attributes, all other prefixes, and returning `Err`. This made RFC 7606 §5.3 treat-as-withdrawal impossible.

Now, NLRI parse errors are caught inside `parse_bgp_update_message` and converted to `BgpValidationWarning::MalformedNlri`. The UPDATE is returned with partial prefix data (empty for the failed NLRI section, intact for the other). Attributes are fully preserved.

```rust
// Before: any NLRI error kills the whole UPDATE
let withdrawn = read_nlri(...)?;     // fail = lose everything
let attributes = parse_attributes(...)?;
let announced = read_nlri(...)?;     // fail = lose withdrawn + attributes

// After: each NLRI section fails independently
let (withdrawn, warn1) = read_nlri(...).ok_or_warning();
let attributes = parse_attributes(...)?;  // framing errors still fatal
let (announced, warn2) = read_nlri(...).ok_or_warning();
```

Attribute framing errors (wrong length fields, truncated data) remain fatal, as they indicate structural corruption that makes the entire message untrustworthy.

### 2. Raw byte preservation (`parse_mrt_record`)

Body-parse failures now attach the original MRT record bytes to `ParserErrorWithBytes.bytes`. Previously this was always `None` for body-level failures, making forensic analysis and record export impossible from the fallible iterator.

### API surface

- `BgpValidationWarning` marked `#[non_exhaustive]` — exhaustive matches must add `_ =>`. This is the only breaking change and is expected at 0.x maturity.
- New variant: `BgpValidationWarning::MalformedNlri { nlri_type: &'static str, reason: String, raw_bytes: Vec<u8> }`
- No struct signature changes. No iterator type changes. Existing iterators are unchanged.

### Example

`examples/treat_as_withdrawal.rs` demonstrates scanning an MRT file, classifying RFC 7606 validation issues by error-handling category, and extracting raw malformed NLRI bytes.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features`: 664 existing tests + 12 new RFC 7606 fixture tests, all passing ✅
- `cargo readme` diff check ✅

New tests cover: malformed announced/withdrawn NLRI, raw byte preservation in warnings, attribute survival across NLRI failure, partial prefix recovery, valid UPDATE still clean, framing errors still fatal, MRT raw byte preservation, Qrator OTC incident scenario, treat-as-withdrawal emulation pattern.